### PR TITLE
Show team ability cd

### DIFF
--- a/NumericUI/scripts/mods/NumericUI/NumericUI_data.lua
+++ b/NumericUI/scripts/mods/NumericUI/NumericUI_data.lua
@@ -40,6 +40,16 @@ return {
 						type = "checkbox",
 						default_value = false,
 					},
+					{
+						setting_id = "ability_cd_bar",
+						type = "checkbox",
+						default_value = true,
+					},					
+					{
+						setting_id = "ability_cd_text",
+						type = "checkbox",
+						default_value = true,
+					},
 				},
 			},
 			{

--- a/NumericUI/scripts/mods/NumericUI/NumericUI_localization.lua
+++ b/NumericUI/scripts/mods/NumericUI/NumericUI_localization.lua
@@ -34,6 +34,12 @@ return {
 		["zh-cn"] = "显示韧性值",
 		ru = "Показывать текст стойкости",
 	},
+	ability_cd_bar = {
+		en = "Show team's ability cooldown as progress bar",
+	},
+	ability_cd_text = {
+		en = "Show team's ability cooldown as numeric counter",
+	},
 	level = {
 		en = "Show level",
 		["zh-cn"] = "显示等级",

--- a/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
+++ b/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
@@ -302,14 +302,13 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 
 	if hide_widgets then
 		if show_ability_text then
+			ability_text_widget.dirty = ability_text_widget.visible
 			ability_text_widget.visible = false
-			ability_text_widget.dirty = true
 		end
 
 		if show_ability_bar then
+			ability_bar_widget.dirty = ability_bar_widget.visible
 			ability_bar_widget.visible = false
-			ability_bar_widget.dirty = true
-
 		end
 
 		return


### PR DESCRIPTION
Offers the option to see the team's cd as either a bar under their health (akin to vt2) and/or as a counter.
#28 