### PR TITLE
Misc bugfixes

### DIFF
--- a/NumericUI/scripts/mods/NumericUI/Interactions.lua
+++ b/NumericUI/scripts/mods/NumericUI/Interactions.lua
@@ -12,13 +12,7 @@ local UIWidget = require("scripts/managers/ui/ui_widget")
 local UIHudSettings = require("scripts/settings/ui/ui_hud_settings")
 local UIRenderer = require("scripts/managers/ui/ui_renderer")
 local Pickups = require("scripts/settings/pickup/pickups")
-
-local current_ammo = nil
-local max_ammo = nil
-local small_clip_gain = 0
-local large_clip_gain = 0
-local ammo_text_width = nil
-local ammo_text_height = 0
+local mod = get_mod("NumericUI")
 
 mod:hook_require(INTERACTIONS_HUD_DEF_PATH, function(instance)
 	local ammo_description_size_mod = 0.9
@@ -40,6 +34,7 @@ mod:hook_require(INTERACTIONS_HUD_DEF_PATH, function(instance)
 			}),
 		},
 	}, "description_box")
+
 end)
 
 mod:hook_safe(
@@ -49,40 +44,40 @@ mod:hook_safe(
 		if mod:get("show_ammo_amount_from_packs") then
 			local ammo_gain_widget = self._widgets_by_name.description_text
 
-			if ammo_gain_widget and max_ammo then
+			if ammo_gain_widget and mod.max_ammo then
 				local ammo_loss_widget = self._widgets_by_name.ammo_loss_description_text
 				local hud_description = interactor_extension:hud_description()
 				local font_size = ammo_gain_widget.style.text.font_size
 				local gap_size = font_size * 0.06
 
-				local missing_ammo = max_ammo - current_ammo
+				local missing_ammo = mod.max_ammo - mod.current_ammo
 				local ammo_gain_text = ""
 				local ammo_loss_text = ""
 				local x_offset = 0
 
 				if hud_description == "loc_pickup_consumable_small_clip_01" then
-					if missing_ammo >= small_clip_gain then
-						ammo_gain_text = string.format("  +%d", small_clip_gain)
+					if missing_ammo >= mod.small_clip_gain then
+						ammo_gain_text = string.format("  +%d", mod.small_clip_gain)
 					elseif missing_ammo > 0 then
 						ammo_gain_text = string.format("  +%d", missing_ammo)
-						ammo_loss_text = string.format("(%d)", (small_clip_gain - missing_ammo))
+						ammo_loss_text = string.format("(%d)", (mod.small_clip_gain - missing_ammo))
 
 						local char_gap = (string.len(ammo_gain_text) - 1) * gap_size
 						x_offset = (
-								ammo_text_width
+								mod.ammo_text_width
 								* string.len(string.format("%s%s", ammo_gain_widget.content.text, ammo_gain_text))
 							) + char_gap
 					end
 				elseif hud_description == "loc_pickup_consumable_large_clip_01" then
-					if missing_ammo >= large_clip_gain then
-						ammo_gain_text = string.format("  +%d", large_clip_gain)
+					if missing_ammo >= mod.large_clip_gain then
+						ammo_gain_text = string.format("  +%d", mod.large_clip_gain)
 					elseif missing_ammo > 0 then
 						ammo_gain_text = string.format("  +%d", missing_ammo)
-						ammo_loss_text = string.format("(%d)", (large_clip_gain - missing_ammo))
+						ammo_loss_text = string.format("(%d)", (mod.large_clip_gain - missing_ammo))
 
 						local char_gap = (string.len(ammo_gain_text) - 1) * gap_size
 						x_offset = (
-								ammo_text_width
+								mod.ammo_text_width
 								* string.len(string.format("%s%s", ammo_gain_widget.content.text, ammo_gain_text))
 							) + char_gap
 					end
@@ -103,40 +98,6 @@ mod:hook_safe("HudElementInteraction", "update", function(self, dt, t, ui_render
 		local description_text_widget = self._widgets_by_name.description_text
 		local font_type = description_text_widget.style.text.font_type
 		local font_size = description_text_widget.style.text.font_size
-		ammo_text_width, ammo_text_height = UIRenderer.text_size(ui_renderer, "0", font_type, font_size)
-	end
-end)
-
-mod:hook_safe("HudElementPlayerWeapon", "init", function(self, amount, total_max_amount)
-	if not self._ability_type then
-		local slot_component = self._slot_component
-		if slot_component then
-			if self._uses_ammo or self._uses_overheat then
-				local max_reserve = slot_component.max_ammunition_reserve
-				local max_ammunition_clip = slot_component.max_ammunition_clip
-				local pickup_data_small_clip = Pickups.by_name["small_clip"]
-				local pickup_data_large_clip = Pickups.by_name["large_clip"]
-
-				max_ammo = max_reserve + max_ammunition_clip
-				current_ammo = max_ammo
-
-				small_clip_gain = pickup_data_small_clip.ammo_amount_func(
-					max_reserve,
-					max_ammunition_clip,
-					pickup_data_small_clip
-				)
-				large_clip_gain = pickup_data_large_clip.ammo_amount_func(
-					max_reserve,
-					max_ammunition_clip,
-					pickup_data_large_clip
-				)
-			end
-		end
-	end
-end)
-
-mod:hook_safe("HudElementPlayerWeapon", "set_ammo_amount", function(self, total_ammo, total_max_ammo)
-	if total_max_ammo == max_ammo then
-		current_ammo = total_ammo
+		mod.ammo_text_width, mod.ammo_text_height = UIRenderer.text_size(ui_renderer, "0", font_type, font_size)
 	end
 end)

--- a/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
+++ b/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
@@ -293,12 +293,9 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 		ability_cooldown_timer[player:name()] = 0
 	end
 
-	local time = Managers.time:time("gameplay")
-	local time_remaining = ability_component.cooldown - time
 	local hide_widgets = (self._show_as_dead or self._dead or self._hogtied)
 	local show_ability_text = (mod:get("ability_cd_text") and ability_text_widget)
-	local show_ability_bar = (mod:get("ability_cd_bar") and ability_bar_widget)
-	
+	local show_ability_bar = (mod:get("ability_cd_bar") and ability_bar_widget)	
 
 	if hide_widgets then
 		if show_ability_text then
@@ -325,6 +322,7 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 		if show_ability_bar then
 			ability_bar_widget.style.texture.color = UIHudSettings.color_tint_8
 			ability_bar_widget.style.texture.size[1] = bar_size[1]
+			ability_bar_widget.visible = true
 			ability_bar_widget.dirty = true
 		end
 	
@@ -345,6 +343,8 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 		end
 
 	elseif ability_cooldown_timer[player:name()] == 0 then
+		local time = Managers.time:time("gameplay")
+		local time_remaining = ability_component.cooldown - time
 		ability_max_cooldown[player:name()] = time_remaining
 		ability_cooldown_timer[player:name()] = dt
 
@@ -357,6 +357,7 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 		if show_ability_bar then
 			ability_bar_widget.style.texture.color = UIHudSettings.color_tint_9
 			ability_bar_widget.style.texture.size[1] = bar_size[1] * (ability_cooldown_timer[player:name()]/ability_max_cooldown[player:name()])
+			ability_bar_widget.visible = true
 			ability_bar_widget.dirty = true
 		end
 
@@ -371,7 +372,8 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 
 		if show_ability_bar then
 			ability_bar_widget.style.texture.color = UIHudSettings.color_tint_9
-			ability_bar_widget.style.texture.size[1] = bar_size[1] * (ability_cooldown_timer[player:name()]/ability_max_cooldown[player:name()])
+			local cd_progress = math.clamp(ability_cooldown_timer[player:name()]/ability_max_cooldown[player:name()], 0, 1.0)
+			ability_bar_widget.style.texture.size[1] = bar_size[1] * cd_progress
 			ability_bar_widget.dirty = true
 		end
 	end
@@ -479,16 +481,16 @@ mod:hook_safe("HudElementTeamPlayerPanel", "init", function(self, parent, draw_l
 				end
 			end
 
-      local archetype = unit_data_extension:archetype_name()
-      local peril_widget = self._widgets_by_name.numeric_ui_peril_icon
+			local archetype = unit_data_extension:archetype_name()
+			local peril_widget = self._widgets_by_name.numeric_ui_peril_icon
 
-      if mod:get("peril_icon") then
-        peril_widget.content.warning_text = "" -- this boxed questionmark is the character for the peril icon
-        peril_widget.visible = (archetype == "psyker")
+			if mod:get("peril_icon") then
+				peril_widget.content.warning_text = "" -- this boxed questionmark is the character for the peril icon
+				peril_widget.visible = (archetype == "psyker")
 
-      elseif mod:get("ammo_text") then
-        peril_widget.content.warning_text = ""
-        peril_widget.visible = (archetype == "psyker") -- I use the "visible" flag to determine if it's a psyker
+			elseif mod:get("ammo_text") then
+				peril_widget.content.warning_text = ""
+				peril_widget.visible = (archetype == "psyker") -- I use the "visible" flag to determine if it's a psyker
 			end
 		end
 	end

--- a/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
+++ b/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
@@ -322,7 +322,6 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 		if show_ability_bar then
 			ability_bar_widget.style.texture.color = UIHudSettings.color_tint_8
 			ability_bar_widget.style.texture.size[1] = bar_size[1]
-			ability_bar_widget.visible = true
 			ability_bar_widget.dirty = true
 		end
 	
@@ -335,6 +334,11 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 		end
 
 		if show_ability_bar then
+			if not ability_bar_widget.visible then
+				ability_bar_widget.visible = true
+				ability_bar_widget.dirty = true
+			end
+			
 			if ability_bar_widget.style.texture.size[1] ~= bar_size[1] then
 				ability_bar_widget.style.texture.color = UIHudSettings.color_tint_8
 				ability_bar_widget.style.texture.size[1] = bar_size[1]
@@ -380,6 +384,33 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 end
 
 mod:hook("HudElementPlayerPanelBase", "init", hud_init_with_features)
+
+mod:hook_safe("HudElementPlayerPanelBase", "destroy", function (self, ui_renderer)
+	local player_extensions = self:_player_extensions(self._data.player)
+	if mod:get("ability_cd_bar") or mod:get("ability_cd_text") then
+		if player_extensions then
+			local unit_data_extension = player_extensions.unit_data
+			if unit_data_extension then
+					ability_component = unit_data_extension:read_component("combat_ability")
+					ability_cooldown_timer[data.player:name()] = nil
+					if ability_component then
+						ability_max_cooldown[data.player:name()] = nil
+					end
+				end
+			end
+		end
+
+		if (mod:get("ability_cd_text") and ability_text_widget) then
+			self._widgets_by_name.ability_text.visible = false
+			self._widgets_by_name.ability_text.dirty = true
+		end
+
+		if (mod:get("ability_cd_bar") and ability_bar_widget) then
+			self._widgets_by_name.ability_bar_widget.visible = false
+			self._widgets_by_name.ability_bar_widget.dirty = true
+		end
+	end
+end)
 
 local function update_ammo_count(func, self, dt, t, player, ui_renderer)
 	func(self, dt, t, player, ui_renderer)
@@ -495,3 +526,4 @@ mod:hook_safe("HudElementTeamPlayerPanel", "init", function(self, parent, draw_l
 		end
 	end
 end)
+

--- a/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
+++ b/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
@@ -391,11 +391,10 @@ mod:hook_safe("HudElementPlayerPanelBase", "destroy", function (self, ui_rendere
 		if player_extensions then
 			local unit_data_extension = player_extensions.unit_data
 			if unit_data_extension then
-					ability_component = unit_data_extension:read_component("combat_ability")
-					ability_cooldown_timer[data.player:name()] = nil
-					if ability_component then
-						ability_max_cooldown[data.player:name()] = nil
-					end
+				ability_component = unit_data_extension:read_component("combat_ability")
+				ability_cooldown_timer[data.player:name()] = nil
+				if ability_component then
+					ability_max_cooldown[data.player:name()] = nil
 				end
 			end
 		end


### PR DESCRIPTION
- Code cleanup + small optimization
- Fixed a bug where ammo packs would show ammo gained/wasted when using a weapon that doesn't use ammo.
- Fixed a bug that caused the ability bar to extend past 100% length.
- Fixed an issue that would create broken/incorrect cooldown text when a player leaves or joins an ongoing game session.
- Fixed a bug that causes the ability cd bar to never re-appear after disappearing following a player's death.