### PR TITLE
fix(PingMonitor): Show only icon if NaN

### DIFF
--- a/PingMonitor/scripts/mods/PingMonitor/PingMonitor.lua
+++ b/PingMonitor/scripts/mods/PingMonitor/PingMonitor.lua
@@ -73,7 +73,7 @@ mod:hook_safe("HudElementTacticalOverlay", "update", function(self)
 	if self._active then
 		local color = mod.ping_color(mod.jitter, mod.ping)
 		local ping_widget = self._widgets_by_name.ping_monitor
-		ping_widget.content.ping_text = mod.ping
+		ping_widget.content.ping_text = mod.ping ~= mod.ping and "" or mod.ping
 		ping_widget.style.ping_text.text_color = color
 		ping_widget.style.ping_icon.color = color
 		ping_widget.dirty = true


### PR DESCRIPTION
Just leave the little guy on the left when in prologue/psykhanium.

<img width="83" alt="image" src="https://user-images.githubusercontent.com/5785323/231968057-a2d9bb89-19fc-4a90-ae70-985fc09b9e03.png">