### PR TITLE
hotfix boss > 2 healthbar errors

### DIFF
--- a/NumericUI/scripts/mods/NumericUI/BossHealth.lua
+++ b/NumericUI/scripts/mods/NumericUI/BossHealth.lua
@@ -119,7 +119,7 @@ mod:hook_safe("HudElementBossHealth", "update", function(self)
 	if mod:get("show_boss_health_numbers") then
 		local widget_groups = self._widget_groups
 		local active_targets_array = self._active_targets_array
-		local num_active_targets = #active_targets_array
+		local num_active_targets = math.min(2, #active_targets_array)
 
 		for i = 1, num_active_targets do
 			local widget_group_index = num_active_targets > 1 and i + 1 or i


### PR DESCRIPTION
```
15:22:10.404 [Lua] [MOD][NumericUI][ERROR] (safe_hook): [string "./../mods/NumericUI/scripts/mods/NumericUI/Bo..."]:130: attempt to index local 'widget_group' (a nil value)
15:22:10.421 [Lua] Error: [string "./../mods/NumericUI/scripts/mods/NumericUI/Bo..."]:130: attempt to index local 'widget_group' (a nil value)
<Lua Script.Callstack>
  [0] =[C]: in function callstack
  [1] ./../mods/dmf/scripts/mods/dmf/modules/core/safe_calls.lua:19: in function __index
  [2] ./../mods/NumericUI/scripts/mods/NumericUI/BossHealth.lua:130:in function <[string "./../mods/NumericUI/scripts/mods/NumericUI/Bo..."]:118>
  [3] =[C]: in function xpcall
  [4] ./../mods/dmf/scripts/mods/dmf/modules/core/safe_calls.lua:66: in function safe_call_nr
  [5] ./../mods/dmf/scripts/mods/dmf/modules/core/hooks.lua:183:in function <[string "./../mods/dmf/scripts/mods/dmf/modules/core/h..."]:181>
  [6] ./../mods/dmf/scripts/mods/dmf/modules/core/hooks.lua:202: in function update
  [7] @scripts/managers/ui/ui_hud.lua:400: in function update
  [8] @scripts/managers/ui/ui_manager.lua:1036: in function post_update
  [9] @scripts/game_states/state_game.lua:845: in function update
  [10] @scripts/foundation/utilities/game_state_machine.lua:126: in function update
  [11] ./mod_loader:397: in function update
  [12] ./mod_loader:437:in function <[string "./mod_loader"]:436>
</Lua Script.Callstack>
<Lua Script.Locals>
  [1] error_message = "[string \"./../mods/NumericUI/scripts/mods/NumericUI/Bo...\"]:130: attempt to index local \'widget_group\' (a nil value)"
  [2] self = table: 000000008D8E0830; widget_groups = table: 000000008BC96340; active_targets_array = table: 000000008E517D60; num_active_targets = 3; i = 3; widget_group_index = 4; widget_group = nil; target = table: 0000000091D3D080; unit = [Unit \'#ID[dbfdfa17636f96a8]\']
  [4] mod = table: 0000000085C1F530; error_prefix_data = "(safe_hook)"; func = [function]
  [6] hook_chain = [function]; num_values = 0; values = table: 0000000093758A70; safe_hooks = table: 0000000089956B80; i = 1
  [7] self = table: 000000008B0C25B0; dt = 0.015219399705529213; t = 1786.5510310088248; input_service = table: 00000000836C32C0; ui_renderer = table: 0000000088189810; player_unit = [Unit \'#ID[f888cbd0f5a35360]\']; elements_hud_scale_lookup = table: 00000000881892A0; currently_visible_elements = table: 0000000088189DA0; elements_array = table: 0000000088189270; hud_scale_applied = true; render_settings = table: 0000000088189720; resolution_modified = nil; i = 26; element = table: 000000008D8E0830; element_name = "HudElementBossHealth"
  [8] self = table: 000000008258FAB0; dt = 0.015219399705529213; t = 1786.5510310088248; hud = table: 000000008B0C25B0; spectator_hud = nil; constant_element_using_input = false; input_service = table: 00000000836C32C0
  [9] self = table: 0000000080111A50; dt = 0.015219399705529213; network_is_active = true; t = 1786.5510310088248; ui_manager = table: 000000008258FAB0
  [10] self = table: 000000008018AC40; dt = 0.015219399705529213; t = nil
  [11] self = table: 000000008005EE10; dt = 0.015219399705529213
  [12] dt = 0.015219399705529213
</Lua Script.Locals>
<Lua Script.Self>
  [2] _definitions = table: 00000000899515A0; _widgets_by_name = table: 000000008E517D30; _active_targets_array = table: 000000008E517D60; _parent = table: 000000008B0C25B0; _is_active = true; _hidden_scenegraphs = table: 0000000086E5A360; _ui_scenegraph = table: 000000008D7B4480; _widget_groups = table: 000000008BC96340; _active_targets_by_unit = table: 000000008E517A70; _event_list = table: 000000008D7B4450; _widgets = table: 000000008E518020; _draw_layer = 301; _max_health_bars = 2; _queued_targets = table: 000000008E517AA0; 
  [7] _world_name = "level_world"; _visibility_groups = table: 0000000084C3AC30; _element_using_input = false; _current_group_name = "alive"; _extensions = table: 000000008A603640; _refresh_retained = true; _elements_array = table: 0000000088189270; _player_viewport_name = "player1"; _element_definitions = table: 000000008C5BF8E0; _currently_visible_elements = table: 0000000088189DA0; _ui_renderer_name = "UIHud_table000000008B0C25B0_UIHud_ui_renderer"; _tactical_overlay_active = false; _camera = [Camera]; _unique_id = "UIHud_table000000008B0C25B0_"; _elements = table: 0000000088189240; _ui_renderer = table: 0000000088189810; _params = table: 000000008B0C2580; _player = table: 00000000886E15F0; _world_viewport_name = "player1"; _elements_hud_scale_lookup = table: 00000000881892A0; _elements_hud_retained_mode_lookup = table: 000000008C5BF8B0; _render_settings = table: 0000000088189720; 
  [8] _renderers = table: 000000008266A590; _current_state_name = "StateGameplay"; _packages_to_remove = table: 000000008083DE50; _ui_loading_icon_renderer = table: 0000000082904ED0; _visible_widgets = table: 000000008266B1F0; _world_draw_layer = 20; _timer_name = "ui"; _single_icon_renderers_marked_for_destruction_array = table: 0000000082721410; _loading_reason = table: 0000000082A7DDE0; _default_world_layer = 20; _back_buffer_render_handlers = table: 00000000827244C0; _active_popups = table: 000000008266BDA0; _world_name = "ui_world"; _world = [World]; _package_unload_list = table: 000000008266A560; _viewport = [Viewport]; _hud = table: 000000008B0C25B0; _render_target_atlas_generator = table: 00000000827214A0; _single_icon_renderers = table: 00000000827213E0; _current_sub_state_name = "GameplayStateRun"; _disable_input = false; _views_loading_data = table: 0000000082668A00; _ui_element_package_references = table: 000000008266BD70; _loading_state_data = table: 0000000082A64EF0; _view_handler = table: 00000000829FAAE0; _ui_extension_managers = table: 000000008234FA50; _popup_id_counter = 3; _input_service_name = "View"; _close_view_input_action = "back"; _viewport_name = "ui_world_viewport"; _ui_inputs_in_use = table: 0000000082685C40; _prev_visible_widgets = table: 000000008266B1C0; _input_hold_tracker = table: 00000000808494C0; _ui_constant_elements = table: 00000000833735C0; _client_waiting_loadout = false; 
  [9] _vo_sources_cache = table: 000000008018CD70; _approve_channel_delegate = table: 00000000800C2D00; _event_delegate = table: 0000000080111AD0; _sm = table: 0000000080207330; 
  [10] _log_breadcrumbs = true; _state = table: 0000000080111A50; _name = "Main"; _state_change_callbacks = table: 000000008018ACE0; 
  [11] _package_manager = table: 0000000080139410; _sm = table: 000000008018AC40; 
</Lua Script.Self>
```