### PR TITLE
remove hard-coded boss health numbers limit

### DIFF
--- a/NumericUI/scripts/mods/NumericUI/BossHealth.lua
+++ b/NumericUI/scripts/mods/NumericUI/BossHealth.lua
@@ -119,7 +119,7 @@ mod:hook_safe("HudElementBossHealth", "update", function(self)
 	if mod:get("show_boss_health_numbers") then
 		local widget_groups = self._widget_groups
 		local active_targets_array = self._active_targets_array
-		local num_active_targets = math.min(2, #active_targets_array)
+		local num_active_targets = math.min(#widget_groups - 1, #active_targets_array)
 
 		for i = 1, num_active_targets do
 			local widget_group_index = num_active_targets > 1 and i + 1 or i


### PR DESCRIPTION
Ref: [Recolor Boss Health Bars](https://www.nexusmods.com/warhammer40kdarktide/mods/314?tab=files) now supports custom number of lines of boss health bars

This commit adds hp number to every health bar
