### PR TITLE
feature(HUDTweaker): API for other mods to add custom ImGui options

### DIFF
--- a/HUDTweaker/scripts/mods/HUDTweaker/HUDTweaker.lua
+++ b/HUDTweaker/scripts/mods/HUDTweaker/HUDTweaker.lua
@@ -20,9 +20,189 @@ local function set_in(tbl, path, val)
 	end
 end
 
+-- Save tweak and load
 local function set_style_tweak(path, val)
 	set_in(style_tweaks, path, val)
 	mod:set("style_tweaks", style_tweaks)
+end
+
+
+
+-- Table that stores external option definitions persistently between reloads.
+-- Structure: _custom_options[<hud_element>][<id>] = option_definition
+local _custom_options = mod:persistent_table("custom_options")
+
+-- Simple id counter so handles don’t shift after removals.
+_custom_options._next_id = _custom_options._next_id or 0
+
+-- Draw helpers for each control type
+
+-- Imgui helpers keyed by `type`
+local CONTROL_HANDLERS = {
+    button = function(opt, label, element, widget)
+        if Imgui.small_button(label) and opt.action then
+            opt.action(element, widget)
+        end
+    end,
+
+    checkbox = function(opt, label)
+        local current = opt.get and opt.get() or false
+        local new_val = Imgui.checkbox(label, current)
+        if new_val ~= current and opt.set then
+            opt.set(new_val)
+        end
+    end,
+
+    slider_int = function(opt, label)
+        local val = opt.get and opt.get() or 0
+        local new_val = Imgui.slider_int(label, val, opt.min or 0, opt.max or 100)
+        if new_val ~= val and opt.set then
+            opt.set(new_val)
+        end
+    end,
+
+    slider_float = function(opt, label)
+        local val = opt.get and opt.get() or 0.0
+        local new_val = Imgui.slider_float(label, val, opt.min or 0.0, opt.max or 1.0)
+        if new_val ~= val and opt.set then
+            opt.set(new_val)
+        end
+    end,
+
+    input_text = function(opt, label)
+        local val = opt.get and opt.get() or ""
+        local new_val = Imgui.input_text(label, val)
+        if new_val ~= val and opt.set then
+            opt.set(new_val)
+        end
+    end,
+}
+
+
+_custom_options._style_index = _custom_options._style_index or {}
+
+-- helper – give it element/widget/style/key to set up the control
+function mod.register_style_option(def)
+    if type(def) ~= "table" then
+        return
+    end
+
+    local element = def.hud_element
+    local widget = def.widget
+    local style_id = def.style_id
+    local key = def.key
+    if not (element and widget and style_id and key) then
+        return
+    end
+
+    -- Compose unique index key.
+    local idx_key = table.concat({element, widget, style_id, key}, ":")
+    if _custom_options._style_index[idx_key] then
+        -- Already registered, skip
+        return _custom_options._style_index[idx_key]
+    end
+
+    local path = {element, widget, style_id, key}
+
+    -- Auto-detect control type
+    local value = def.value -- caller may pass current value to avoid lookup later
+    local ctrl_type = def.type
+    if not ctrl_type then
+        if type(value) == "boolean" then
+            ctrl_type = "checkbox"
+        elseif type(value) == "number" then
+            ctrl_type = (value % 1 == 0) and "slider_int" or "slider_float"
+        else
+            return 
+        end
+    end
+
+    local option_def = {
+        hud_element = element,
+        widget      = widget,
+        label       = def.label or key,
+        type        = ctrl_type,
+        min         = def.min,
+        max         = def.max,
+        get         = function()
+            -- navigate style_tweaks else fall back to original value
+            local t = style_tweaks
+            for i = 1, #path do
+                t = t and t[path[i]]
+            end
+            if t ~= nil then
+                return t
+            end
+            return value
+        end,
+        set         = function(v)
+            set_style_tweak(path, v)
+        end,
+    }
+
+    local handle = mod.register_option(option_def)
+
+    _custom_options._style_index[idx_key] = handle
+    return handle
+end
+
+-- Draw one registered option.
+local function _draw_registered_option(opt, element, widget)
+    -- Imgui not ready? bail.
+    if not Imgui then
+        return
+    end
+
+    if opt.draw then
+        opt.draw(element, widget)
+        return
+    end
+
+    local label = opt.label or "Unnamed"
+    local control_type = opt.type or "button"
+
+    local handler = CONTROL_HANDLERS[control_type]
+    if handler then
+        handler(opt, label, element, widget)
+    else
+        Imgui.text(string.format("[Unsupported option type: %s]", tostring(control_type)))
+    end
+end
+
+-- register_option(def_table) -> handle
+-- Adds a control described above. Returns a stable handle for later removal.
+-- unregister_option(hud_element, handle) removes it again.
+function mod.register_option(definition)
+    if type(definition) ~= "table" then
+        mod:echo("[HUDTweaker] register_option expects a table definition")
+        return nil
+    end
+
+    if type(definition.hud_element) ~= "string" then
+        mod:echo("[HUDTweaker] register_option requires 'hud_element' string field")
+        return nil
+    end
+
+    -- Generate a stable id so the handle stays valid even when other
+    -- options are removed.
+    _custom_options._next_id = (_custom_options._next_id or 0) + 1
+    local id = _custom_options._next_id
+
+    definition._id = id -- for easy debugging
+
+    -- Bucket options per HUD element.
+    _custom_options[definition.hud_element] = _custom_options[definition.hud_element] or {}
+    local bucket = _custom_options[definition.hud_element]
+    bucket[id] = definition
+
+    return id
+end
+
+function mod.unregister_option(hud_element, handle)
+    local bucket = _custom_options[hud_element]
+    if bucket then
+        bucket[handle] = nil
+    end
 end
 
 mod:hook_safe("HudElementBase", "init", function(self)
@@ -172,9 +352,29 @@ function HUDTweaker:update()
 
 						table_to_tree(widget.style, { class_name, widget_name })
 
+						-- Draw custom options registered for this widget (specific)
+						local element_options = _custom_options[class_name]
+						if element_options then
+						    for _, opt in pairs(element_options) do
+						        if opt.widget == widget_name then
+						            _draw_registered_option(opt, element, widget)
+						        end
+						    end
+						end
+
 						widget.dirty = true
 						Imgui.tree_pop()
 					end
+				end
+
+				-- Draw element level custom options (widget=nil)
+				local element_options = _custom_options[class_name]
+				if element_options then
+				    for _, opt in pairs(element_options) do
+				        if not opt.widget then
+				            _draw_registered_option(opt, element, nil)
+				        end
+				    end
 				end
 				Imgui.tree_pop()
 			end


### PR DESCRIPTION
 - register_option – lets other mods add buttons/sliders/checkboxes to any HUD element
  - register_style_option – expose a single numeric /boolean style field
  - unregister_option – removes a previously added control by handle

--------
local ht = get_mod("HUDTweaker")

  ht.register_option{
      hud_element = "HudElementPlayerWeapon",
      widget      = "ammo_text",   -- optional
      label       = "Show ammo %",
      type        = "checkbox",
      get         = function() return MyMod:get("show_ammo_pct") end,
      set         = function(v)   MyMod:set("show_ammo_pct", v)  end,
  }

  -- or for a single style field
  ht.register_style_option{
      hud_element = "HudElementPlayerWeapon",
      widget      = "ammo_text",
      style_id    = "text",
      key         = "offset_x",
      min         = -100,          -- optional
      max         = 100,
  }