### PR TITLE
fix(healthbars): preload inventory icon packages

### DIFF
--- a/Healthbars/scripts/mods/Healthbars/Healthbars.lua
+++ b/Healthbars/scripts/mods/Healthbars/Healthbars.lua
@@ -17,6 +17,19 @@ mod.colors = {
 	toxin = { 255, 0, 255, 0 },
 }
 
+function mod.on_all_mods_loaded()
+    -- Preload icon packages
+    local function load_package(package_name)
+        if not Managers.package:has_loaded(package_name) then
+            Managers.package:load(package_name, "Healthbars")
+        end
+    end
+
+    load_package("packages/ui/views/inventory_view/inventory_view")
+    load_package("packages/ui/views/inventory_weapons_view/inventory_weapons_view")
+    load_package("packages/ui/hud/player_weapon/player_weapon")
+end
+
 mod:hook_safe("HudElementWorldMarkers", "init", function(self)
 	self._marker_templates[MarkerTemplate.name] = MarkerTemplate
 end)


### PR DESCRIPTION
Preload UI packages for inventory, weapons, and background views when the game state changes. This ensures preset icons are available when needed, otherwise they can be colored squares instead.

Killfeed Details is doing same thing and that is from where I originally took the icon references:

```lua
mod.on_game_state_changed = function(state, state_name)
    -- Preload Preset Icons
    Managers.package:load("packages/ui/views/inventory_view/inventory_view", "KillfeedDetails", nil, true)
    Managers.package:load("packages/ui/views/inventory_weapons_view/inventory_weapons_view", "KillfeedDetails", nil, true)
    Managers.package:load("packages/ui/views/inventory_background_view/inventory_background_view", "KillfeedDetails", nil, true)
    Managers.package:load("packages/ui/views/inventory_weapon_details_view/inventory_weapon_details_view", "KillfeedDetails", nil, true)
    -- Preload Weapon Icons
    Managers.package:load("packages/ui/hud/player_weapon/player_weapon", "KillfeedDetails", nil, true)
    Managers.package:load("packages/ui/views/inventory_weapon_marks_view/inventory_weapon_marks_view", "KillfeedDetails", nil, true)
    -- Other stuff that probably isn't needed but don't dare remove just yet
    Managers.package:load("packages/ui/views/cosmetics_inspect_view/cosmetics_inspect_view", "KillfeedDetails", nil, true)
    Managers.package:load("packages/ui/views/masteries_overview_view/masteries_overview_view", "KillfeedDetails", nil, true)
end
```