### PR TITLE
perf: cache outline slot colors

### DIFF
--- a/CareerColourOutlines/scripts/mods/CareerColourOutlines/CareerColourOutlines.lua
+++ b/CareerColourOutlines/scripts/mods/CareerColourOutlines/CareerColourOutlines.lua
@@ -1,5 +1,33 @@
 local mod = get_mod("CareerColourOutlines")
 local UISettings = require("scripts/settings/ui/ui_settings")
+local player_slot_colors = UISettings.player_slot_colors
+local player_manager = Managers.player
+local slot_color_vectors = {}
+local set_outline_color = Unit.set_vector3_for_materials
+
+local function _slot_color_vector(player_slot)
+	if not player_slot then
+		return nil
+	end
+
+	local cached = slot_color_vectors[player_slot]
+
+	if cached ~= nil then
+		return cached ~= false and cached or nil
+	end
+
+	local player_slot_color = player_slot_colors[player_slot]
+
+	if not player_slot_color then
+		slot_color_vectors[player_slot] = false
+		return nil
+	end
+
+	cached = Vector3(player_slot_color[2] / 255, player_slot_color[3] / 255, player_slot_color[4] / 255)
+	slot_color_vectors[player_slot] = cached
+
+	return cached
+end
 
 mod:hook_safe("OutlineSystem", "update", function(self)
 	if self._total_num_outlines == 0 then
@@ -11,18 +39,16 @@ mod:hook_safe("OutlineSystem", "update", function(self)
 	end
 
 	for unit, extension in pairs(self._unit_extension_data) do
-		local player = Managers.player:player_by_unit(unit)
+		local player = player_manager:player_by_unit(unit)
 
 		if player then
 			local top_outline = extension.outlines[1]
 
 			if top_outline then
-				local player_slot = player:slot()
-				local player_slot_color = UISettings.player_slot_colors[player_slot]
-				if player_slot_color then
-					local color =
-						Vector3(player_slot_color[2] / 255, player_slot_color[3] / 255, player_slot_color[4] / 255)
-					Unit.set_vector3_for_materials(unit, "outline_color", color, true)
+				local color = _slot_color_vector(player:slot())
+
+				if color then
+					set_outline_color(unit, "outline_color", color, true)
 				end
 			end
 		end


### PR DESCRIPTION
This keeps the existing outline behavior the same, but avoids rebuilding the same slot color vector every frame for every outlined player.

What changed:
- Cache the per-slot outline `Vector3` values instead of recreating them inside `OutlineSystem:update`
- Cache a couple of hot references (`Managers.player`, `Unit.set_vector3_for_materials`, `UISettings.player_slot_colors`) to reduce repeated lookup work in the update path

Why:
- `OutlineSystem:update` runs frequently
- the old code rebuilt the same `Vector3` for each player slot on every pass
- caching the slot colors removes repeated allocations and cuts a bit of per-frame work in a hot path

Behavior:
- no intended functional change
- outline colors still come from `UISettings.player_slot_colors`

Validation:
- syntax checked with `luac51 -p`
- tested locally in-game; this was part of a broader pass that noticeably improved UI-side performance on my setup

Thank you!