### PR TITLE
Add healthbar label toggle for armor type or enemy name.

### DIFF
--- a/Healthbars/scripts/mods/Healthbars/HealthbarMarker.lua
+++ b/Healthbars/scripts/mods/Healthbars/HealthbarMarker.lua
@@ -14,6 +14,7 @@ local math_huge = math.huge
 local math_max = math.max
 local math_min = math.min
 local math_pow = math.pow
+local string_find = string.find
 local string_format = string.format
 local table_clear = table.clear
 local table_clone = table.clone
@@ -81,6 +82,9 @@ local armor_type_string_lookup = {
 	berserker = "loc_weapon_stats_display_berzerker",
 	unarmored = "loc_weapon_stats_display_unarmored",
 }
+local DEFAULT_HIT_ZONE_NAME = "center_mass"
+local LABEL_DISPLAY_MODE_ARMOUR_TYPE = "armour_type"
+local LABEL_DISPLAY_MODE_ENEMY_NAME = "enemy_name"
 
 template.fade_settings = {
 	fade_to = 1,
@@ -97,6 +101,60 @@ template.fade_settings = {
 
 local function _set_rgb(dst, src)
 	dst[2], dst[3], dst[4] = src[2], src[3], src[4]
+end
+
+local function _localize_or_fallback(loc_key, fallback)
+	if not loc_key or loc_key == "" then
+		return fallback or ""
+	end
+
+	local localized_text = Localize(loc_key)
+	if localized_text == "" or string_find(localized_text, "<unlocalized") then
+		return fallback or ""
+	end
+
+	return localized_text
+end
+
+local function _localized_breed_name(breed)
+	if not breed then
+		return ""
+	end
+
+	return _localize_or_fallback(breed.display_name, "")
+end
+
+local function _damage_label_enabled()
+	return mod:get("show_armour_type") == true
+end
+
+local function _damage_label_display_mode()
+	return mod:get("show_armour_type_display") or LABEL_DISPLAY_MODE_ARMOUR_TYPE
+end
+
+local function _damage_label_uses_hit_zone()
+	return _damage_label_enabled() and _damage_label_display_mode() == LABEL_DISPLAY_MODE_ARMOUR_TYPE
+end
+
+local function _damage_label_text(ui_content)
+	local display_mode = _damage_label_display_mode()
+
+	if display_mode == LABEL_DISPLAY_MODE_ENEMY_NAME then
+		return ui_content.enemy_name_text or _localized_breed_name(ui_content.breed)
+	end
+
+	local hit_zone_name = ui_content.last_hit_zone_name or DEFAULT_HIT_ZONE_NAME
+
+	local breed = ui_content.breed
+	local armor_type = breed and breed.armor_type
+
+	if breed and breed.hitzone_armor_override and breed.hitzone_armor_override[hit_zone_name] then
+		armor_type = breed.hitzone_armor_override[hit_zone_name]
+	end
+
+	local armor_type_loc_string = armor_type and armor_type_string_lookup[armor_type] or ""
+
+	return _localize_or_fallback(armor_type_loc_string, "")
 end
 
 -- ---------------------------------------------------------------------------
@@ -151,6 +209,29 @@ end
 -- ---------------------------------------------------------------------------
 -- Damage number rendering (logic pass)
 -- ---------------------------------------------------------------------------
+
+local function _draw_damage_label(template, ui_renderer, ui_style, ui_content, position)
+	if not ui_content.damage_has_started or not _damage_label_enabled() then
+		return
+	end
+
+	local settings = template.damage_number_settings
+	local scale = RESOLUTION_LOOKUP.scale
+	local font_type = ui_style.font_type
+	local font_size = settings.dps_font_size * scale
+	local label_text = _damage_label_text(ui_content)
+
+	if label_text == "" then
+		return
+	end
+
+	local z0 = position[3]
+	local x0 = position[1] + settings.x_offset
+	local y0 = position[2] + settings.y_offset
+	local label_pos = Vector3(x0, y0 - settings.has_taken_damage_timer_y_offset, z0)
+
+	UIRenderer_draw_text(ui_renderer, label_text, font_size, font_type, label_pos, ui_style.size, ui_style.text_color, {})
+end
 
 local function _draw_damage_numbers(template, mod, ui_renderer, ui_style, ui_content, position)
 	if not mod:get("show_damage_numbers") then
@@ -256,24 +337,6 @@ local function _draw_damage_numbers(template, mod, ui_renderer, ui_style, ui_con
 		end
 	end
 
-	-- Armour type label
-	if ui_content.damage_has_started and ui_content.last_hit_zone_name and mod:get("show_armour_type") then
-		local hit_zone_name = ui_content.last_hit_zone_name
-		local breed = ui_content.breed
-		local armor_type = breed.armor_type
-
-		if breed.hitzone_armor_override and breed.hitzone_armor_override[hit_zone_name] then
-			armor_type = breed.hitzone_armor_override[hit_zone_name]
-		end
-
-		local armor_type_loc_string = armor_type and armor_type_string_lookup[armor_type] or ""
-		local armor_type_text = Localize(armor_type_loc_string)
-		local armor_pos = Vector3(x0, y0 - settings.has_taken_damage_timer_y_offset, z0)
-
-		UIRenderer_draw_text(ui_renderer, armor_type_text, dps_font_size, font_type, armor_pos, ui_style.size,
-			ui_style.text_color, {})
-	end
-
 	-- restore values for any later pass that might use them
 	ui_style.font_size = default_font_size
 	position[3], position[2], position[1] = z0, y0, x0
@@ -334,6 +397,7 @@ template.create_widget_defintion = function(template, scenegraph_id)
 			pass_type = "logic",
 			value = function(pass, ui_renderer, ui_style, ui_content, position, size)
 				_draw_damage_numbers(template, mod, ui_renderer, ui_style, ui_content, position)
+				_draw_damage_label(template, ui_renderer, ui_style, ui_content, position)
 			end,
 			style = {
 				horizontal_alignment = "left",
@@ -411,7 +475,7 @@ template.create_widget_defintion = function(template, scenegraph_id)
 		local slot = SLOT_CACHE[i]
 		local icon_id = slot.icon_id
 		local stacks_id = slot.stacks_id
-		local x, y = _slot_pos(i, mod:get("show_damage_numbers") and mod:get("show_armour_type"))
+		local x, y = _slot_pos(i, _damage_label_enabled())
 
 		passes[#passes + 1] = {
 			pass_type = "texture",
@@ -471,6 +535,7 @@ template.on_enter = function(widget, marker, template)
 
 	content.header_text = breed.name
 	content.breed = breed
+	content.enemy_name_text = _localized_breed_name(breed)
 	content.weakspots = breed.hit_zone_weakspot_types
 
 	marker.debuff_check_timer = 0
@@ -1186,8 +1251,9 @@ template.update_function = function(parent, ui_renderer, widget, marker, templat
 	local style = widget.style
 	local unit = marker.unit
 	local show_damage_numbers = mod:get("show_damage_numbers")
-	local show_armour_type = mod:get("show_armour_type")
-	local use_armour_slot_offset = show_damage_numbers and show_armour_type
+	local use_armour_slot_offset = _damage_label_enabled()
+	local needs_last_hit_zone = show_damage_numbers or _damage_label_uses_hit_zone()
+	local needs_hit_reaction_data = show_damage_numbers
 
 	local health_extension = ScriptUnit_has_extension(unit, "health_system")
 	local is_dead = not health_extension or not health_extension:is_alive()
@@ -1380,14 +1446,18 @@ template.update_function = function(parent, ui_renderer, widget, marker, templat
 		damage_taken = max_health
 	end
 
-	if health_extension then
+	if health_extension and (needs_last_hit_zone or needs_hit_reaction_data) then
 		local last_damaging_unit = health_extension:last_damaging_unit()
 		if last_damaging_unit then
-			content.last_hit_zone_name = health_extension:last_hit_zone_name() or "center_mass"
+			if needs_last_hit_zone then
+				content.last_hit_zone_name = health_extension:last_hit_zone_name() or "center_mass"
+			end
 
-			local weakspots = content.weakspots
-			content.hit_weakspot = weakspots and weakspots[content.last_hit_zone_name] and true or false
-			content.was_critical = health_extension:was_hit_by_critical_hit_this_render_frame()
+			if needs_hit_reaction_data then
+				local weakspots = content.weakspots
+				content.hit_weakspot = weakspots and weakspots[content.last_hit_zone_name] and true or false
+				content.was_critical = health_extension:was_hit_by_critical_hit_this_render_frame()
+			end
 		end
 	end
 

--- a/Healthbars/scripts/mods/Healthbars/Healthbars_data.lua
+++ b/Healthbars/scripts/mods/Healthbars/Healthbars_data.lua
@@ -61,6 +61,18 @@ local widgets = {
 						setting_id = "show_armour_type",
 						type = "checkbox",
 						default_value = true,
+
+						sub_widgets = {
+							{
+								setting_id = "show_armour_type_display",
+								type = "dropdown",
+								default_value = "armour_type",
+								options = {
+									{ text = "display_armour_type", value = "armour_type" },
+									{ text = "display_enemy_name", value = "enemy_name" },
+								},
+							},
+						},
 					},
 				},
 			},

--- a/Healthbars/scripts/mods/Healthbars/Healthbars_localization.lua
+++ b/Healthbars/scripts/mods/Healthbars/Healthbars_localization.lua
@@ -44,11 +44,20 @@ local localization = {
 		fr = "Affiche les DPS",
 	},
 	show_armour_type = {
-		en = "Show armour type hit",
+		en = "Show info label",
 		["zh-cn"] = "显示命中护甲类型",
 		["zh-tw"] = "顯示命中護甲類型",
 		ru = "Тип поражённой брони",
 		fr = "Affiche le type d'armure touché",
+	},
+	show_armour_type_display = {
+		en = "Label text",
+	},
+	display_armour_type = {
+		en = "Armour type",
+	},
+	display_enemy_name = {
+		en = "Enemy name",
 	},
 	horde_breeds = {
 		en = "Horde/Roamer",

--- a/doc/Healthbars/README.md
+++ b/doc/Healthbars/README.md
@@ -1,25 +1,29 @@
 ## Healthbars
 
-**Healthbars** brings Psykhanium-style enemy healthbars into regular missions and expands them with optional combat readouts. The mod can show enemy health bars, floating damage numbers, a DPS readout, armour type feedback, and a configurable set of DoT and debuff indicators above the bar.
+**Healthbars** brings Psykhanium-style enemy healthbars into regular missions and expands them with optional combat readouts. The mod can show enemy health bars, floating damage numbers, a DPS readout, a configurable info label, and a set of DoT and debuff indicators above the bar.
 
 ### What it includes
 - **Enemy healthbars** for selected enemy types in regular game modes
 - **Damage numbers** when tracked enemies take damage
 - **DPS report** for tracked targets after the damage window ends
-- **Armour type feedback** for the last hit zone
+- **Info label** above the bar
+  - **Armour type**
+  - **Enemy name**
+- **Localized enemy names** using the game's normal display names
+- **Safe localization fallback** that avoids showing internal ids or `<unlocalized ...>` text
 - **DoT indicators**
-    - **Bleed** stacks
-    - **Burn** stacks
-    - **Warpfire / Soulblaze** stacks
-    - **Toxin** stacks
+  - **Bleed** stacks
+  - **Burn** stacks
+  - **Warpfire / Soulblaze** stacks
+  - **Toxin** stacks
 - **Debuff indicators**
-    - **Brittleness indicator** (rending % against relevant armor types)
-    - **Electrocuted** (presence indicator)
-    - **Skullcrusher** (damage vs staggered, stacks / % / time)
-    - **Thunderstrike** (impact modifier, stacks / % / time)
-    - **Melee damage taken** (from multiple sources, icon-only or %)
-    - **Increased total damage taken** (combined from several buffs, icon-only or %)
-    - **Empyric Shock** (warp damage taken, stacks / % / time)
+  - **Brittleness indicator** (rending % against relevant armor types)
+  - **Electrocuted** (presence indicator)
+  - **Skullcrusher** (damage vs staggered, stacks / % / time)
+  - **Thunderstrike** (impact modifier, stacks / % / time)
+  - **Melee damage taken** (from multiple sources, icon-only or %)
+  - **Increased total damage taken** (combined from several buffs, icon-only or %)
+  - **Empyric Shock** (warp damage taken, stacks / % / time)
 
 ---
 
@@ -31,7 +35,7 @@ Open the mod options and look under **"Toggle features"**.
 - Show health bar
 - Show damage numbers
 - Show DPS report
-- Show armour type hit
+- Show info label
 - Show bleed stacks
 - Show burn stacks
 - Show warpfire (Soulblaze) stacks
@@ -59,6 +63,7 @@ This lets you keep the display focused on the enemies that matter most to you.
 
 ### Display modes (per effect)
 Some effects have a display dropdown:
+- **Info label**: `Armour type` / `Enemy name`
 - **Brittleness**: `Icon + text %` / `Icon only` / `Time (s)`
 - **Skullcrusher**: `Stacks` / `Percent %` / `Icon only` / `Time (s)`
 - **Thunderstrike**: `Stacks` / `Percent %` / `Icon only` / `Time (s)`
@@ -77,14 +82,14 @@ Some effects have a display dropdown:
 
 - Indicators are displayed in an **8-column grid** with up to **2 rows**.
 - If any debuff is active:
-    - **Debuffs** occupy the first visual row.
-    - **DoTs** shift into the second visual row.
+  - **Debuffs** occupy the first visual row.
+  - **DoTs** shift into the second visual row.
 - If no debuff is active:
-    - **DoTs** occupy the first visual row.
+  - **DoTs** occupy the first visual row.
 
 ### Ordering
-- DoTs: `Bleed` → `Burn` → `Warpfire` → `Toxin`
-- Debuffs: `Brittleness` → `Damage Taken` → `Melee Damage Taken` → `Skullcrusher` → `Thunderstrike` → `Empyric Shock` → `Electrocuted`
+- DoTs: `Bleed` -> `Burn` -> `Warpfire` -> `Toxin`
+- Debuffs: `Brittleness` -> `Damage Taken` -> `Melee Damage Taken` -> `Skullcrusher` -> `Thunderstrike` -> `Empyric Shock` -> `Electrocuted`
 
 ---
 
@@ -96,12 +101,12 @@ Some effects have a display dropdown:
 | **Burn** | <img src="icons/burn.png" width="50"> | DoT stacks from `burning` | Stacks | Fixed color, orange flame tint. |
 | **Warpfire (Soulblaze)** | <img src="icons/warpfire_color_option_three.png" width="50"> | DoT stacks from `warp_fire` | Stacks | <img src="icons/warpfire_color_option_one.png" width="25"> **Warp-Core**<br/><img src="icons/warpfire_color_option_two.png" width="25"> **Soulblaze Cyan**<br/><img src="icons/warpfire_color_option_three.png" width="25"> **Sanctified Cerulean** (default)<br/><img src="icons/warpfire_color_option_four.png" width="25"> **Ethereal Blue**<br/><img src="icons/warpfire_color_option_five.png" width="25"> **Peril Purple** |
 | **Toxin** | <img src="icons/toxin.png" width="50"> | Combined DoT stacks from the tracked neurotoxin and exploding toxin interval buffs | Stacks | Fixed color, toxic green tint. |
-| **Brittleness** | <img src="icons/brittleness_white.png" width="50"> | Total rending % from: `rending_debuff` (2.5%/stack, cap 16), `rending_burn_debuff` (1%/stack, cap 20), `shotgun_special_rending_debuff` (25%/stack, cap 1), `saw_rending_debuff` (2.5%/stack, cap 15). **Only shown for armor types:** Flak, Carapace, Maniac, Unyielding. Hidden below **2.5%**. | `Icon + %` / `Icon only` / `Time (s)` | <img src="icons/brittleness_white.png" width="25"> **2.5-19.9%**<br/><img src="icons/brittleness_yellow.png" width="25"> **20-29.9%**<br/><img src="icons/brittleness_orange.png" width="25"> **30-39.9%**<br/><img src="icons/brittleness_red.png" width="25"> **40-59.9%**<br/><img src="icons/brittleness_magenta.png" width="25"> **≥60%** |
+| **Brittleness** | <img src="icons/brittleness_white.png" width="50"> | Total rending % from: `rending_debuff` (2.5%/stack, cap 16), `rending_burn_debuff` (1%/stack, cap 20), `shotgun_special_rending_debuff` (25%/stack, cap 1), `saw_rending_debuff` (2.5%/stack, cap 15). **Only shown for armor types:** Flak, Carapace, Maniac, Unyielding. Hidden below **2.5%**. | `Icon + %` / `Icon only` / `Time (s)` | <img src="icons/brittleness_white.png" width="25"> **2.5-19.9%**<br/><img src="icons/brittleness_yellow.png" width="25"> **20-29.9%**<br/><img src="icons/brittleness_orange.png" width="25"> **30-39.9%**<br/><img src="icons/brittleness_red.png" width="25"> **40-59.9%**<br/><img src="icons/brittleness_magenta.png" width="25"> **>=60%** |
 | **Electrocuted** | <img src="icons/electrocuted.png" width="50"> | Presence of any supported electrocution-related buff template, for example shock effects, mauls, mines, or chain lightning style effects | No text | Fixed color, pale electrocuted tint. |
 | **Skullcrusher** | <img src="icons/skullcrusher_white.png" width="50"> | Stagger damage taken debuff: `increase_damage_received_while_staggered` with fallback `damage_vs_staggered`. **10% per stack**, cap **8**. | `Stacks` / `Percent %` / `Icon only` / `Time (s)` | <img src="icons/skullcrusher_white.png" width="25"> **1-2** / 10-20%<br/><img src="icons/skullcrusher_yellow.png" width="25"> **3-4** / 30-40%<br/><img src="icons/skullcrusher_orange.png" width="25"> **5-6** / 50-60%<br/><img src="icons/skullcrusher_red.png" width="25"> **7-8** / 70-80% |
 | **Thunderstrike** | <img src="icons/thunderstrike_white.png" width="50"> | Impact modifier debuff: `increase_impact_received_while_staggered` with fallback `impact_modifier`. **10% per stack**, cap **8**. | `Stacks` / `Percent %` / `Icon only` / `Time (s)` | <img src="icons/thunderstrike_white.png" width="25"> **1-2** / 10-20%<br/><img src="icons/thunderstrike_yellow.png" width="25"> **3-4** / 30-40%<br/><img src="icons/thunderstrike_orange.png" width="25"> **5-6** / 50-60%<br/><img src="icons/thunderstrike_red.png" width="25"> **7-8** / 70-80% |
 | **Melee damage taken** | <img src="icons/melee_damage_taken_white.png" width="50"> | Counts active sources: `ogryn_staggering_damage_taken_increase` and `adamant_staggering_enemies_take_more_damage`. Each source adds **+15%** additively. | `Icon + %` / `Icon only` | <img src="icons/melee_damage_taken_white.png" width="25"> **1 source (15%)**<br/><img src="icons/melee_damage_taken_red.png" width="25"> **2 sources (30%)** |
-| **Increased damage taken (total)** | <img src="icons/damage_taken_white.png" width="50"> | Computes combined damage taken increase from multiple supported buffs, additive modifiers, multipliers, tag stacks, and special cases | `Icon + %` / `Icon only` | <img src="icons/damage_taken_white.png" width="25"> **0-14.9%**<br/><img src="icons/damage_taken_yellow.png" width="25"> **15-29.9%**<br/><img src="icons/damage_taken_orange.png" width="25"> **30-44.9%**<br/><img src="icons/damage_taken_red.png" width="25"> **45-59.9%**<br/><img src="icons/damage_taken_magenta.png" width="25"> **≥60%** |
+| **Increased damage taken (total)** | <img src="icons/damage_taken_white.png" width="50"> | Computes combined damage taken increase from multiple supported buffs, additive modifiers, multipliers, tag stacks, and special cases | `Icon + %` / `Icon only` | <img src="icons/damage_taken_white.png" width="25"> **0-14.9%**<br/><img src="icons/damage_taken_yellow.png" width="25"> **15-29.9%**<br/><img src="icons/damage_taken_orange.png" width="25"> **30-44.9%**<br/><img src="icons/damage_taken_red.png" width="25"> **45-59.9%**<br/><img src="icons/damage_taken_magenta.png" width="25"> **>=60%** |
 | **Empyric Shock** | <img src="icons/empyric_shock_white.png" width="50"> | Psyker debuff `psyker_force_staff_quick_attack_debuff`: **+6% warp damage taken per stack**, cap **5**, combined multiplicatively | `Stacks` / `Percent %` / `Time (s)` | <img src="icons/empyric_shock_white.png" width="25"> **1-2** / 6-12%<br/><img src="icons/empyric_shock_yellow.png" width="25"> **3** / 19%<br/><img src="icons/empyric_shock_orange.png" width="25"> **4** / 26%<br/><img src="icons/empyric_shock_red.png" width="25"> **5** / 34% |
 
 ---
@@ -110,7 +115,11 @@ Some effects have a display dropdown:
 - Healthbars are anchored natively to the enemy **head node** instead of relying on custom world-position logic, which helps prevent the occasional bar-at-the-feet issue.
 - Debuff changes trigger the same visibility window as damage, so indicators can appear when a debuff is applied even if the enemy has not taken direct damage yet.
 - The mod supports **per-enemy healthbar toggles**, grouped by Horde/Roamer, Elite, Special, Monster/Captain, and Ritualist.
-- **Damage numbers**, **DPS**, and **armour type feedback** can be enabled independently.
+- **Damage numbers**, **DPS**, and the **info label** are handled independently, so the label can still work when damage numbers are disabled.
+- **Enemy name** mode uses the game's localized `breed.display_name`.
+- If localization data is missing or broken, the mod hides the label instead of showing internal names or `<unlocalized ...>` placeholders.
+- **Armour type** uses the exact last hit zone when that data is available.
+- In regular missions, the game does not always provide exact hit-zone data for networked enemies on the client, so armour type may fall back to the enemy's default/body armour instead of a more specific head or limb result.
 - **Brittleness** is intentionally suppressed on armor types where it is not meaningful.
 - **Electrocuted** is **presence-only**.
 - **Warpfire** uses a player-selectable icon tint, with **Sanctified Cerulean** as the default option.
@@ -119,10 +128,15 @@ Some effects have a display dropdown:
 
 ## Known issues
 - **Brittleness `Time (s)`** depends on the game exposing reliable duration progress for the active rending buff. On some enemies or situations the icon may remain visible while the timer text is blank.
+- **Armour type** in normal missions may reflect the enemy's default/body armour when exact hit-zone data is unavailable on the client.
 - Percentage text can still be hard to read depending on icon color and background contrast.
 - Very dense fights can produce a lot of simultaneous information if many status toggles are enabled at once.
 
 ## Recent additions
+- Added a configurable **info label** that can show either **armour type** or **enemy name**.
+- Added safe localized enemy-name handling to prevent `<unlocalized ...>` strings or internal breed ids from appearing in the HUD.
+- Decoupled the info label from damage-number rendering so the label can still display when damage numbers are disabled.
+- Added a fallback for **armour type** in regular missions when exact hit-zone data is not available on the client.
 - Added support for a broader status suite, including **Bleed**, **Burn**, **Warpfire**, **Toxin**, **Brittleness**, **Electrocuted**, **Skullcrusher**, **Thunderstrike**, **Melee damage taken**, **Increased damage taken**, and **Empyric Shock**.
 - Added `Time (s)` display mode for **Skullcrusher** and **Thunderstrike**.
 - Improved `Time (s)` behavior so invalid duration data hides the number instead of displaying a misleading `0`.


### PR DESCRIPTION
I added a new option for the small text label on the healthbar. Players can now choose whether it shows the enemy’s armor type or the enemy’s name.

For enemy names, the mod uses the game’s normal translated display name, so it shows names like Crusher or Scab Gunner instead of internal IDs. If the game is missing or breaking a translation, the mod avoids showing ugly placeholder text.

I also changed it so this label works independently from damage numbers, so turning damage numbers off no longer breaks the feature.

One extra thing I had to handle is that the game treats the Psykhanium and normal missions differently under the hood. In the Psykhanium, the game gives exact hit-location info more reliably, but in normal missions it often doesn’t. So for armor type, I added a fallback that shows the enemy’s default armor category when the exact hit-location armor isn’t available, instead of leaving the label blank.

Updated README.md
closes #164 