### PR TITLE
Adding AML support to .mod file. 

### DIFF
--- a/LogMeIn/LogMeIn.mod
+++ b/LogMeIn/LogMeIn.mod
@@ -8,6 +8,11 @@ return {
 			mod_localization = "LogMeIn/scripts/mods/LogMeIn/LogMeIn_localization",
 		})
 	end,
+
+ load_after = {
+ "dmf"
+ "ErrorTracker",
+ },
 	packages = {},
 	version = "26.04.12",
 	mod_id = "15",

--- a/LogMeIn/LogMeIn.mod
+++ b/LogMeIn/LogMeIn.mod
@@ -10,7 +10,7 @@ return {
 	end,
 
  load_after = {
- "dmf"
+ "dmf",
  "ErrorTracker",
  },
 	packages = {},


### PR DESCRIPTION
This puts LogMeIn at the top of the load order, however when ErrorTracker is installed it will be below it in the list. 