### PR TITLE
Fix negative ability cooldown values

### DIFF
--- a/NumericUI/scripts/mods/NumericUI/PlayerAbility.lua
+++ b/NumericUI/scripts/mods/NumericUI/PlayerAbility.lua
@@ -59,7 +59,7 @@ mod:hook_safe("HudElementPlayerAbility", "update", function(self)
 				local unit_data_extension = ScriptUnit.extension(player_unit, "unit_data_system")
 				local ability_state_component = unit_data_extension:read_component("combat_ability")
 				local time = Managers.time:time("gameplay")
-				local time_remaining = ability_state_component.cooldown - time
+				local time_remaining = math.max(ability_state_component.cooldown - time, 0)
 				if time_remaining <= 1 then
 					text_widget.content.text = string.format("%.1f", time_remaining)
 				else

--- a/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
+++ b/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
@@ -349,7 +349,8 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 		ability_cooldown_timer[player:name()] = ability_cooldown_timer[player:name()] + dt
 
 		if show_ability_text then
-			local cd_timer = ability_max_cooldown[player:name()] - ability_cooldown_timer[player:name()]
+			local cd_timer =
+				math.max(ability_max_cooldown[player:name()] - ability_cooldown_timer[player:name()], 0)
 			ability_text_widget.content.text = string.format("%03d", cd_timer)
 			ability_text_widget.dirty = true
 		end


### PR DESCRIPTION
Clamp local and teammate cooldown displays at zero to prevent timing overshoots from rendering negative values.

Closes #197 