### PR TITLE
Fix Shivs counter drifting to top-left

### DIFF
--- a/NumericUI/scripts/mods/NumericUI/PlayerWeapon.lua
+++ b/NumericUI/scripts/mods/NumericUI/PlayerWeapon.lua
@@ -438,7 +438,7 @@ mod:hook_safe("HudElementPlayerWeapon", "update", function(self, _dt, _t, ui_ren
 				self._prev_ammo = total_ammo
 			end
 		end
-	elseif mod:get("show_munitions_gained") and uses_ammo then --This one checks for grenades gained
+	elseif mod:get("show_munitions_gained") and uses_ammo and not self._uses_weapon_special_charges then --This one checks for grenades gained
 		local grenade_gained_widget = self._widgets_by_name.grenade_gained
 		local total_ammo = self._total_ammo
 


### PR DESCRIPTION
Exclude weapon-special-charge HUD elements from the grenade-gained animation, leaving the Shivs counter under vanilla HUD handling.

Closes #198 