### PR TITLE
Fix frame-time degradation from per-frame HUD updates (#199)

### DIFF
--- a/NumericUI/scripts/mods/NumericUI/HudElementDodgeCount.lua
+++ b/NumericUI/scripts/mods/NumericUI/HudElementDodgeCount.lua
@@ -19,6 +19,25 @@ local scenegraph_definition = {
 local color_efficient = Color.terminal_text_header(255, true)
 local color_inefficient = Color.ui_hud_warp_charge_low(255, true)
 local color_limit = Color.ui_hud_warp_charge_high(255, true)
+local color_timer_hidden = Color.text_default(0, true)
+
+-- timer gradient colors by color name, so the update loop never allocates new color tables
+local timer_gradient_colors = {}
+local function _timer_gradient_color(color_name)
+	local color = timer_gradient_colors[color_name]
+	if not color then
+		color = Color[color_name](255, true)
+		timer_gradient_colors[color_name] = color
+	end
+	return color
+end
+
+local function _copy_color(destination, source)
+	destination[1] = source[1]
+	destination[2] = source[2]
+	destination[3] = source[3]
+	destination[4] = source[4]
+end
 
 local timer_x_offset = (-UIWorkspaceSettings.screen.size[1] + scenegraph_definition.container.size[1]) / 2
 
@@ -35,8 +54,8 @@ local timer_size_color = function(time_to_refresh, cooldown, current_dodges, for
 	timer_size[1] = mod:get("dodge_timer_width") * (1 - natural_time)
 	timer_size[2] = mod:get("dodge_timer_height")
 
-	local color_start = Color[mod:get("color_start")](255, true)
-	local color_end = Color[mod:get("color_end")](255, true)
+	local color_start = _timer_gradient_color(mod:get("color_start"))
+	local color_end = _timer_gradient_color(mod:get("color_end"))
 	for i = 1, 4 do
 		timer_color[i] = math.lerp(color_start[i], color_end[i], natural_time)
 	end
@@ -165,8 +184,9 @@ HudElementDodgeCount.update = function(self, dt, t, ui_renderer, render_settings
 		return
 	end
 
+	-- copy into the widget's own color table in place instead of cloning a new one every frame
 	local style = self._widgets_by_name.dodge_count.style
-	style.text.text_color = table.clone(color_efficient)
+	_copy_color(style.text.text_color, color_efficient)
 
 	local unit_data_extension = ScriptUnit.extension(self._player_unit, "unit_data_system")
 	local weapon_extension = ScriptUnit.has_extension(self._player_unit, "weapon_system")
@@ -207,7 +227,7 @@ HudElementDodgeCount.update = function(self, dt, t, ui_renderer, render_settings
 			timer_size_color(relative_time, relative_cooldown, current_dodges, force_show_max_width)
 
 		self._widgets_by_name.dodge_timer.style.timer.size = timer_size or ZERO_SIZE
-		self._widgets_by_name.dodge_timer.style.timer.color = timer_color or Color.text_default(0, true)
+		self._widgets_by_name.dodge_timer.style.timer.color = timer_color or color_timer_hidden
 
 		if num_efficient_dodges == math.huge then
 			if mod:get("show_dodge_count_for_infinite_dodge") then
@@ -226,11 +246,11 @@ HudElementDodgeCount.update = function(self, dt, t, ui_renderer, render_settings
 		end
 
 		if current_dodges >= num_efficient_dodges then
-			style.text.text_color = table.clone(color_inefficient)
+			_copy_color(style.text.text_color, color_inefficient)
 		end
 
 		if current_dodges >= math.floor(dr_limit + num_efficient_dodges) then
-			style.text.text_color = table.clone(color_limit)
+			_copy_color(style.text.text_color, color_limit)
 		end
 
 		if mod:get("fade_out_max_dodges") and current_dodges == 0 then

--- a/NumericUI/scripts/mods/NumericUI/PlayerAbility.lua
+++ b/NumericUI/scripts/mods/NumericUI/PlayerAbility.lua
@@ -47,12 +47,21 @@ mod:hook_safe("HudElementPlayerAbility", "update", function(self)
 	local on_cooldown = self._on_cooldown
 
 	if text_widget then
-		local percent = progress * 100
+		local content = text_widget.content
+		-- new_text stays nil while the displayed value is unchanged, so the
+		-- retained widget is only re-rendered when the text actually changes
+		local new_text
+
 		if not on_cooldown or progress >= 1 then
-			text_widget.content.text = " "
+			content._numericui_last_value = nil
+			new_text = " "
 		else
 			if ability_cooldown_format == "percent" then
-				text_widget.content.text = string.format("%d%%", percent)
+				local percent = math.floor(progress * 100)
+				if content._numericui_last_value ~= percent then
+					content._numericui_last_value = percent
+					new_text = string.format("%d%%", percent)
+				end
 			elseif ability_cooldown_format == "time" then
 				local player = self._data.player
 				local player_unit = player.player_unit
@@ -61,15 +70,25 @@ mod:hook_safe("HudElementPlayerAbility", "update", function(self)
 				local time = Managers.time:time("gameplay")
 				local time_remaining = math.max(ability_state_component.cooldown - time, 0)
 				if time_remaining <= 1 then
-					text_widget.content.text = string.format("%.1f", time_remaining)
+					content._numericui_last_value = nil
+					new_text = string.format("%.1f", time_remaining)
 				else
-					text_widget.content.text = string.format("%d", time_remaining)
+					local seconds = math.floor(time_remaining)
+					if content._numericui_last_value ~= seconds then
+						content._numericui_last_value = seconds
+						new_text = string.format("%d", seconds)
+					end
 				end
 			else
-				text_widget.content.text = " "
+				content._numericui_last_value = nil
+				new_text = " "
 			end
 		end
-		text_widget.dirty = true
+
+		if new_text and content.text ~= new_text then
+			content.text = new_text
+			text_widget.dirty = true
+		end
 	end
 
 	if mod:get("disable_ability_background_progress") then

--- a/NumericUI/scripts/mods/NumericUI/PlayerWeapon.lua
+++ b/NumericUI/scripts/mods/NumericUI/PlayerWeapon.lua
@@ -33,6 +33,11 @@ local ammo_gained_data = {
 	alpha_multiplier = 1,
 }
 
+-- reusable scratch storage for Ammo.clips_in_use (fully overwritten on every call)
+local _clips_in_use_scratch = {}
+-- "ammo_text_" .. i built once instead of every frame
+local _ammo_text_widget_names = {}
+
 local directional_magnitude = 200
 for i = 1, 4 do
 	directional_magnitude = directional_magnitude * -1
@@ -304,7 +309,6 @@ mod:hook_safe("HudElementPlayerWeapon", "update", function(self, _dt, _t, ui_ren
 			if not max_reserve or max_reserve <= 0 then
 				return
 			end
-			local _clips_in_use_scratch = {}
 			local any_clip_in_use = Ammo.clips_in_use(slot_component, _clips_in_use_scratch)
 
 			if not any_clip_in_use then
@@ -324,8 +328,17 @@ mod:hook_safe("HudElementPlayerWeapon", "update", function(self, _dt, _t, ui_ren
 			local ammo_icon_offset_x = 0
 			local ammo_icon_offset_y = 0
 
+			local show_max_ammo_text = mod:get("max_ammo_text")
+			local show_max_ammo_as_percent = mod:get("show_max_ammo_as_percent")
+
 			for i = 1, NetworkConstants.clips_in_use.max_size do
-				local ammo_text_widget = self._widgets_by_name["ammo_text_" .. i]
+				local widget_name = _ammo_text_widget_names[i]
+				if not widget_name then
+					widget_name = "ammo_text_" .. i
+					_ammo_text_widget_names[i] = widget_name
+				end
+
+				local ammo_text_widget = self._widgets_by_name[widget_name]
 				local max_clip = Ammo.max_ammo_in_clips(slot_component, i) or 0
 				local current_clip = Ammo.current_ammo_in_clips(slot_component, i) or 0
 
@@ -343,19 +356,30 @@ mod:hook_safe("HudElementPlayerWeapon", "update", function(self, _dt, _t, ui_ren
 				if ammo_text_widget then
 					local content = ammo_text_widget.content
 					local style = ammo_text_widget.style
-					ammo_text_widget.content.max_ammo = ""
 
-					if mod:get("max_ammo_text") and max_reserve then
-						local display_text = ""
-						if mod:get("show_max_ammo_as_percent") then
-							display_text =
-								string.format("%d%%", math.min(total_current_ammo / total_max_ammo * 100, 100))
+					if show_max_ammo_text and max_reserve then
+						local max_ammo_value
+						if show_max_ammo_as_percent then
+							max_ammo_value = math.floor(math.min(total_current_ammo / total_max_ammo * 100, 100))
 						else
-							display_text = string.format("/%d", max_reserve)
+							max_ammo_value = max_reserve
 						end
-						content.max_ammo = display_text
+
+						-- only rebuild the string when the displayed value changes
+						if content._numericui_max_ammo_value ~= max_ammo_value then
+							content._numericui_max_ammo_value = max_ammo_value
+
+							if show_max_ammo_as_percent then
+								content.max_ammo = string.format("%d%%", max_ammo_value)
+							else
+								content.max_ammo = string.format("/%d", max_ammo_value)
+							end
+						end
 
 						style.max_ammo.drop_shadow = true
+					elseif content.max_ammo ~= "" then
+						content._numericui_max_ammo_value = nil
+						content.max_ammo = ""
 					end
 				end
 			end

--- a/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
+++ b/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
@@ -42,6 +42,7 @@ local tough_text_style = {
 
 local ability_max_cooldown = {} -- "player ID -> max cooldown"
 local ability_cooldown_timer = {} -- "player ID -> cooldown timer"
+local ability_bar_cooldown_color = Color.terminal_background_gradient_selected(255, true)
 
 mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 	if mod:get("health_text") or mod:get("toughness_text") then
@@ -268,8 +269,10 @@ mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 end)
 
 local function update_numericui_ability_cd(self, player, ability_bar_widget, ability_text_widget, ability_component, dt)
-	if not ability_cooldown_timer[player:name()] then
-		ability_cooldown_timer[player:name()] = 0
+	local player_name = player:name()
+
+	if not ability_cooldown_timer[player_name] then
+		ability_cooldown_timer[player_name] = 0
 	end
 
 	local hide_widgets = (self._show_as_dead or self._dead or self._hogtied)
@@ -290,8 +293,10 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 		return
 	end
 
-	if ability_component.num_charges > 0 and ability_cooldown_timer[player:name()] > 0 then
-		ability_cooldown_timer[player:name()] = 0
+	local cooldown_timer = ability_cooldown_timer[player_name]
+
+	if ability_component.num_charges > 0 and cooldown_timer > 0 then
+		ability_cooldown_timer[player_name] = 0
 
 		if show_ability_text then
 			ability_text_widget.visible = false
@@ -303,7 +308,7 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 			ability_bar_widget.style.texture.size[1] = bar_size[1]
 			ability_bar_widget.dirty = true
 		end
-	elseif ability_component.num_charges > 0 and ability_cooldown_timer[player:name()] == 0 then
+	elseif ability_component.num_charges > 0 and cooldown_timer == 0 then
 		if show_ability_text then
 			if show_ability_text.visible then
 				show_ability_text.visible = false
@@ -323,44 +328,58 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 				ability_bar_widget.dirty = true
 			end
 		end
-	elseif
-		(ability_cooldown_timer[player:name()] == 0)
-		or (ability_cooldown_timer[player:name()] > ability_max_cooldown[player:name()])
-	then
+	elseif (cooldown_timer == 0) or (cooldown_timer > ability_max_cooldown[player_name]) then
 		local fixed_frame_t = FixedFrame.get_latest_fixed_time()
 		local time_remaining = math.max(ability_component.cooldown - fixed_frame_t, 0)
-		ability_max_cooldown[player:name()] = time_remaining
-		ability_cooldown_timer[player:name()] = dt
+		ability_max_cooldown[player_name] = time_remaining
+		ability_cooldown_timer[player_name] = dt
 
 		if show_ability_text then
 			ability_text_widget.visible = true
 			ability_text_widget.content.text = string.format("%03d", time_remaining)
+			ability_text_widget.content._numericui_last_value = math.floor(time_remaining)
 			ability_text_widget.dirty = true
 		end
 
 		if show_ability_bar then
-			ability_bar_widget.style.texture.color = Color.terminal_background_gradient_selected(255, true)
-			ability_bar_widget.style.texture.size[1] = bar_size[1]
-				* (ability_cooldown_timer[player:name()] / ability_max_cooldown[player:name()])
+			ability_bar_widget.style.texture.color = ability_bar_cooldown_color
+			ability_bar_widget.style.texture.size[1] = bar_size[1] * (dt / time_remaining)
 			ability_bar_widget.visible = true
 			ability_bar_widget.dirty = true
 		end
-	elseif ability_cooldown_timer[player:name()] > 0 then
-		ability_cooldown_timer[player:name()] = ability_cooldown_timer[player:name()] + dt
+	elseif cooldown_timer > 0 then
+		cooldown_timer = cooldown_timer + dt
+		ability_cooldown_timer[player_name] = cooldown_timer
 
 		if show_ability_text then
-			local cd_timer =
-				math.max(ability_max_cooldown[player:name()] - ability_cooldown_timer[player:name()], 0)
-			ability_text_widget.content.text = string.format("%03d", cd_timer)
-			ability_text_widget.dirty = true
+			local cd_timer = math.max(ability_max_cooldown[player_name] - cooldown_timer, 0)
+			local content = ability_text_widget.content
+			local display_value = math.floor(cd_timer)
+
+			-- only re-render the text when the displayed value changes
+			if content._numericui_last_value ~= display_value then
+				content._numericui_last_value = display_value
+				local text = string.format("%03d", cd_timer)
+
+				if content.text ~= text then
+					content.text = text
+					ability_text_widget.dirty = true
+				end
+			end
 		end
 
 		if show_ability_bar then
-			ability_bar_widget.style.texture.color = Color.terminal_background_gradient_selected(255, true)
-			local cd_progress =
-				math.clamp(ability_cooldown_timer[player:name()] / ability_max_cooldown[player:name()], 0, 1.0)
-			ability_bar_widget.style.texture.size[1] = bar_size[1] * cd_progress
-			ability_bar_widget.dirty = true
+			local texture_style = ability_bar_widget.style.texture
+			texture_style.color = ability_bar_cooldown_color
+
+			local cd_progress = math.clamp(cooldown_timer / ability_max_cooldown[player_name], 0, 1.0)
+			-- quantize to whole pixels so the retained bar only re-renders when it visibly grows
+			local bar_width = math.floor(bar_size[1] * cd_progress + 0.5)
+
+			if texture_style.size[1] ~= bar_width then
+				texture_style.size[1] = bar_width
+				ability_bar_widget.dirty = true
+			end
 		end
 	end
 end
@@ -446,27 +465,41 @@ local function update_numericui_player_features(func, self, dt, t, player, ui_re
 				end
 			end
 
-			if total_max_ammo == 0 or self._show_as_dead or self._dead or self._hogtied then
-				-- No ammo or dead
-				ammo_text_widget.content.text = ""
-			elseif
-				total_max_ammo == 0
-				and (peril_icon_widget and peril_icon_widget.visible)
-				and mod:get("peril_text")
+			local show_as_empty = total_max_ammo == 0 or self._show_as_dead or self._dead or self._hogtied
+
+			-- only re-render the retained widget when the displayed values change
+			if
+				total_current_ammo ~= self._numericui_ammo_current
+				or total_max_ammo ~= self._numericui_ammo_max
+				or show_as_empty ~= self._numericui_ammo_empty
 			then
-				-- Ammo text as peril percent
-				ammo_text_widget.content.text = string.format("%1d%%", math.round(warp_charge_level * 100))
-				ammo_text_widget.style.text.text_color = peril_color
-			else
-				-- Ammo
-				if mod:get("ammo_as_percent") then
-					ammo_text_widget.content.text = string.format("%1d%%", (total_current_ammo / total_max_ammo) * 100)
+				self._numericui_ammo_current = total_current_ammo
+				self._numericui_ammo_max = total_max_ammo
+				self._numericui_ammo_empty = show_as_empty
+
+				if show_as_empty then
+					-- No ammo or dead
+					ammo_text_widget.content.text = ""
+				elseif
+					total_max_ammo == 0
+					and (peril_icon_widget and peril_icon_widget.visible)
+					and mod:get("peril_text")
+				then
+					-- Ammo text as peril percent
+					ammo_text_widget.content.text = string.format("%1d%%", math.round(warp_charge_level * 100))
+					ammo_text_widget.style.text.text_color = peril_color
 				else
-					ammo_text_widget.content.text = string.format("%1d/%1d", total_current_ammo, total_max_ammo)
+					-- Ammo
+					if mod:get("ammo_as_percent") then
+						ammo_text_widget.content.text =
+							string.format("%1d%%", (total_current_ammo / total_max_ammo) * 100)
+					else
+						ammo_text_widget.content.text = string.format("%1d/%1d", total_current_ammo, total_max_ammo)
+					end
+					ammo_text_widget.style.text.text_color = self._widgets_by_name.ammo_status.style.ammo.color
 				end
-				ammo_text_widget.style.text.text_color = self._widgets_by_name.ammo_status.style.ammo.color
+				ammo_text_widget.dirty = true
 			end
-			ammo_text_widget.dirty = true
 		end
 	end
 


### PR DESCRIPTION
The team panels, player ability, and player weapon HUD elements render in retained mode: widgets are only re-drawn when marked dirty, and re-drawing recreates engine-side GUI text objects. NumericUI marked its ammo text, team ability cooldown, and local ability cooldown widgets dirty every frame, forcing constant re-renders the base game avoids. It also allocated every frame (scratch tables, color tables, deep clones, format strings), causing GC pressure and stutter.

- TeamPlayerPanel: only rewrite ammo text / cooldown text when the displayed value changes; cache player name and cooldown locals; reuse the cooldown bar color table; quantize bar width to whole pixels so it re-renders per visible pixel instead of per frame
- PlayerWeapon: reuse the clips_in_use scratch table; cache widget names; hoist settings out of the clip loop; only rebuild the max-ammo string when its value changes
- PlayerAbility: only update the cooldown text when the displayed string changes instead of marking the widget dirty every frame
- HudElementDodgeCount: copy colors in place instead of cloning tables every frame; cache timer gradient and hidden-timer colors

Displayed HUD output is unchanged.