### PR TITLE
Publish per-mod changelog text to Nexus

### DIFF
--- a/.template-dmf/CHANGELOG.md
+++ b/.template-dmf/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/.template-dmf/CHANGELOG.md
+++ b/.template-dmf/CHANGELOG.md
@@ -1,0 +1,5 @@
+# %%name Changelog
+
+## 0.0.0
+
+- Changelog tracking initialized.

--- a/CareerColourOutlines/CHANGELOG.md
+++ b/CareerColourOutlines/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CareerColourOutlines Changelog
 
-## 26.04.12-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/CareerColourOutlines/CHANGELOG.md
+++ b/CareerColourOutlines/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CareerColourOutlines Changelog
+
+## 26.04.12-1
+
+- Changelog tracking initialized.

--- a/ChatBlock/CHANGELOG.md
+++ b/ChatBlock/CHANGELOG.md
@@ -1,0 +1,5 @@
+# ChatBlock Changelog
+
+## 26.08.05
+
+- Changelog tracking initialized.

--- a/ChatBlock/CHANGELOG.md
+++ b/ChatBlock/CHANGELOG.md
@@ -1,5 +1,5 @@
 # ChatBlock Changelog
 
-## 26.08.05
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/Clock/CHANGELOG.md
+++ b/Clock/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Clock Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/Clock/CHANGELOG.md
+++ b/Clock/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Clock Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/CustomCrosshairColor/CHANGELOG.md
+++ b/CustomCrosshairColor/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CustomCrosshairColor Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/CustomCrosshairColor/CHANGELOG.md
+++ b/CustomCrosshairColor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CustomCrosshairColor Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/DebugDrawer/CHANGELOG.md
+++ b/DebugDrawer/CHANGELOG.md
@@ -1,5 +1,5 @@
 # DebugDrawer Changelog
 
-## Unreleased
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/DebugDrawer/CHANGELOG.md
+++ b/DebugDrawer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# DebugDrawer Changelog
+
+## Unreleased
+
+- Changelog tracking initialized.

--- a/DisableScreenEffects/CHANGELOG.md
+++ b/DisableScreenEffects/CHANGELOG.md
@@ -1,0 +1,5 @@
+# DisableScreenEffects Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/DisableScreenEffects/CHANGELOG.md
+++ b/DisableScreenEffects/CHANGELOG.md
@@ -1,5 +1,5 @@
 # DisableScreenEffects Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/DiscordRichPresence/CHANGELOG.md
+++ b/DiscordRichPresence/CHANGELOG.md
@@ -1,0 +1,5 @@
+# DiscordRichPresence Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/DiscordRichPresence/CHANGELOG.md
+++ b/DiscordRichPresence/CHANGELOG.md
@@ -1,5 +1,5 @@
 # DiscordRichPresence Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/HUDTweaker/CHANGELOG.md
+++ b/HUDTweaker/CHANGELOG.md
@@ -1,0 +1,5 @@
+# HUDTweaker Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/HUDTweaker/CHANGELOG.md
+++ b/HUDTweaker/CHANGELOG.md
@@ -1,5 +1,5 @@
 # HUDTweaker Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/Healthbars/CHANGELOG.md
+++ b/Healthbars/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Healthbars Changelog
 
-## 26.08.05
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/Healthbars/CHANGELOG.md
+++ b/Healthbars/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Healthbars Changelog
+
+## 26.08.05
+
+- Changelog tracking initialized.

--- a/KillfeedImprovements/CHANGELOG.md
+++ b/KillfeedImprovements/CHANGELOG.md
@@ -1,5 +1,5 @@
 # KillfeedImprovements Changelog
 
-## 26.08.05
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/KillfeedImprovements/CHANGELOG.md
+++ b/KillfeedImprovements/CHANGELOG.md
@@ -1,0 +1,5 @@
+# KillfeedImprovements Changelog
+
+## 26.08.05
+
+- Changelog tracking initialized.

--- a/LogMeIn/CHANGELOG.md
+++ b/LogMeIn/CHANGELOG.md
@@ -1,5 +1,5 @@
 # LogMeIn Changelog
 
-## 26.06.08
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/LogMeIn/CHANGELOG.md
+++ b/LogMeIn/CHANGELOG.md
@@ -1,0 +1,5 @@
+# LogMeIn Changelog
+
+## 26.06.08
+
+- Changelog tracking initialized.

--- a/LuaGCInfo/CHANGELOG.md
+++ b/LuaGCInfo/CHANGELOG.md
@@ -1,5 +1,5 @@
 # LuaGCInfo Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/LuaGCInfo/CHANGELOG.md
+++ b/LuaGCInfo/CHANGELOG.md
@@ -1,0 +1,5 @@
+# LuaGCInfo Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/LuaScratchpad/CHANGELOG.md
+++ b/LuaScratchpad/CHANGELOG.md
@@ -1,0 +1,5 @@
+# LuaScratchpad Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/LuaScratchpad/CHANGELOG.md
+++ b/LuaScratchpad/CHANGELOG.md
@@ -1,5 +1,5 @@
 # LuaScratchpad Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/NoChatColours/CHANGELOG.md
+++ b/NoChatColours/CHANGELOG.md
@@ -1,0 +1,5 @@
+# NoChatColours Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/NoChatColours/CHANGELOG.md
+++ b/NoChatColours/CHANGELOG.md
@@ -1,5 +1,5 @@
 # NoChatColours Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/NumericUI/CHANGELOG.md
+++ b/NumericUI/CHANGELOG.md
@@ -1,0 +1,5 @@
+# NumericUI Changelog
+
+## 26.08.09
+
+- Changelog tracking initialized.

--- a/NumericUI/CHANGELOG.md
+++ b/NumericUI/CHANGELOG.md
@@ -1,5 +1,5 @@
 # NumericUI Changelog
 
-## 26.08.09
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/PingMonitor/CHANGELOG.md
+++ b/PingMonitor/CHANGELOG.md
@@ -1,5 +1,5 @@
 # PingMonitor Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/PingMonitor/CHANGELOG.md
+++ b/PingMonitor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# PingMonitor Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/ProfilePictures/CHANGELOG.md
+++ b/ProfilePictures/CHANGELOG.md
@@ -1,0 +1,5 @@
+# ProfilePictures Changelog
+
+## 26.08.08
+
+- Changelog tracking initialized.

--- a/ProfilePictures/CHANGELOG.md
+++ b/ProfilePictures/CHANGELOG.md
@@ -1,5 +1,5 @@
 # ProfilePictures Changelog
 
-## 26.08.08
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ When editing Traditional Chinese (zh-tw) strings, consult the [Darktide translat
 
 ## Mod changelogs
 
-Each published mod keeps its changelog in `<ModName>/CHANGELOG.md`. Add a heading matching the version in the `.mod` file, for example `## 26.08.10`, followed by the release notes. The release workflow publishes that version section to Nexus Mods and includes the changelog in the downloaded mod archive.
+Each published mod can keep its changelog in `<ModName>/CHANGELOG.md`. Add a heading matching the version in the `.mod` file, for example `## 26.08.10`, followed by the release notes. When available, the release workflow publishes that version section to Nexus Mods and includes the changelog in the downloaded mod archive.

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ When editing Traditional Chinese (zh-tw) strings, consult the [Darktide translat
 
 ## Mod changelogs
 
-Each published mod keeps its changelog in `<ModName>/CHANGELOG.md`. Add a heading matching the version in the `.mod` file, for example `## 26.08.10`, followed by the release notes. The release workflow publishes that version section to Nexus Mods and excludes the changelog from the downloaded mod archive.
+Each published mod keeps its changelog in `<ModName>/CHANGELOG.md`. Add a heading matching the version in the `.mod` file, for example `## 26.08.10`, followed by the release notes. The release workflow publishes that version section to Nexus Mods and includes the changelog in the downloaded mod archive.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@
 ## Traditional Chinese localization
 
 When editing Traditional Chinese (zh-tw) strings, consult the [Darktide translation glossary](https://github.com/SyuanTsai/Warhammer-40-000-DARKTIDE-Mods/blob/main/Referneces/Translation.md). When the glossary lists multiple translations, preserve the existing context-specific terminology unless there is a clear reason to change it.
+
+## Mod changelogs
+
+Each published mod keeps its changelog in `<ModName>/CHANGELOG.md`. Add a heading matching the version in the `.mod` file, for example `## 26.08.10`, followed by the release notes. The release workflow publishes that version section to Nexus Mods and excludes the changelog from the downloaded mod archive.

--- a/ShowEquippedInLobby/CHANGELOG.md
+++ b/ShowEquippedInLobby/CHANGELOG.md
@@ -1,5 +1,5 @@
 # ShowEquippedInLobby Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/ShowEquippedInLobby/CHANGELOG.md
+++ b/ShowEquippedInLobby/CHANGELOG.md
@@ -1,0 +1,5 @@
+# ShowEquippedInLobby Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/TaskbarFlasher/CHANGELOG.md
+++ b/TaskbarFlasher/CHANGELOG.md
@@ -1,0 +1,5 @@
+# TaskbarFlasher Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/TaskbarFlasher/CHANGELOG.md
+++ b/TaskbarFlasher/CHANGELOG.md
@@ -1,5 +1,5 @@
 # TaskbarFlasher Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/Tertium4Or5/CHANGELOG.md
+++ b/Tertium4Or5/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Tertium4Or5 Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/Tertium4Or5/CHANGELOG.md
+++ b/Tertium4Or5/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Tertium4Or5 Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/TrueSoloQoL/CHANGELOG.md
+++ b/TrueSoloQoL/CHANGELOG.md
@@ -1,0 +1,5 @@
+# TrueSoloQoL Changelog
+
+## 26.02.08-1
+
+- Changelog tracking initialized.

--- a/TrueSoloQoL/CHANGELOG.md
+++ b/TrueSoloQoL/CHANGELOG.md
@@ -1,5 +1,5 @@
 # TrueSoloQoL Changelog
 
-## 26.02.08-1
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/rtc/CHANGELOG.md
+++ b/rtc/CHANGELOG.md
@@ -1,0 +1,5 @@
+# rtc Changelog
+
+## Unreleased
+
+- Changelog tracking initialized.

--- a/rtc/CHANGELOG.md
+++ b/rtc/CHANGELOG.md
@@ -1,5 +1,5 @@
 # rtc Changelog
 
-## Unreleased
+## 0.0.0
 
-- Changelog tracking initialized.
+Empty changelog.

--- a/scripts/ci/publish_mods.js
+++ b/scripts/ci/publish_mods.js
@@ -139,7 +139,45 @@ async function resolveFileGroupId(modId, apiKey) {
       `Unexpected response from API: no 'id' in mod file for mod ${modId}`,
     );
   }
-  return fileId;
+  return { fileId, nexusModId: modUuid };
+}
+
+function getChangelogText(modName, version) {
+  const changelogPath = `${modName}/CHANGELOG.md`;
+  if (!fs.existsSync(changelogPath)) {
+    throw new Error(`Missing ${changelogPath}; add a ## ${version} entry before publishing`);
+  }
+
+  const lines = fs
+    .readFileSync(changelogPath, "utf8")
+    .split(/\r?\n/);
+  const headingIndex = lines.findIndex((line) => {
+    const match = line.match(/^#{1,6}\s+(.+?)\s*#*$/);
+    return match && match[1] === version;
+  });
+  if (headingIndex === -1) {
+    throw new Error(`Missing ## ${version} heading in ${changelogPath}`);
+  }
+
+  const section = [];
+  for (let i = headingIndex + 1; i < lines.length; i += 1) {
+    if (/^#{1,6}\s+/.test(lines[i])) break;
+    section.push(lines[i]);
+  }
+
+  const changelogText = section.join("\n").trim();
+  if (!changelogText) {
+    throw new Error(`Empty ## ${version} section in ${changelogPath}`);
+  }
+  return changelogText;
+}
+
+async function publishChangelog(nexusModId, version, changelogText, apiKey) {
+  await apiRequest("POST", `/mods/${nexusModId}/changelogs`, apiKey, {
+    version,
+    changelog: changelogText,
+  });
+  console.log(`  Changelog published for ${version}`);
 }
 
 function getPrevVersion(filePath, before) {
@@ -175,9 +213,13 @@ function getChangedModFiles(before, sha) {
 }
 
 function zipMod(modName) {
-  const result = spawnSync("zip", ["-r", `${modName}.zip`, modName], {
-    encoding: "utf8",
-  });
+  const result = spawnSync(
+    "zip",
+    ["-r", `${modName}.zip`, modName, `-x`, `${modName}/CHANGELOG.md`],
+    {
+      encoding: "utf8",
+    },
+  );
   return result.status === 0 && fs.existsSync(`${modName}.zip`);
 }
 
@@ -408,12 +450,18 @@ async function main() {
     }
 
     let fileGroupId;
+    let nexusModId;
+    let changelogText;
     try {
       console.log(
         `  Resolving file_group_id from API for mod_id=${cur.mod_id}...`,
       );
-      fileGroupId = await resolveFileGroupId(cur.mod_id, apiKey);
+      ({ fileId: fileGroupId, nexusModId } = await resolveFileGroupId(
+        cur.mod_id,
+        apiKey,
+      ));
       console.log(`  Resolved file_group_id: ${fileGroupId}`);
+      changelogText = getChangelogText(modName, cur.version);
     } catch (e) {
       console.error(`Skipping ${modName}: ${e.message}`);
       skipped.push(modName);
@@ -443,6 +491,7 @@ async function main() {
         fileGroupId,
         apiKey,
       );
+      await publishChangelog(nexusModId, cur.version, changelogText, apiKey);
       uploaded.push(modName);
     } catch (e) {
       console.error(`Error uploading ${modName}: ${e.message}`);

--- a/scripts/ci/publish_mods.js
+++ b/scripts/ci/publish_mods.js
@@ -438,6 +438,10 @@ async function main() {
       if (changelogText) {
         console.log(`  Dry run: would publish changelog for ${cur.version}:`);
         console.log(changelogText);
+      } else {
+        console.warn(
+          `  Dry run: no changelog found for ${modName} v${cur.version}`,
+        );
       }
       uploaded.push(modName);
       continue;

--- a/scripts/ci/publish_mods.js
+++ b/scripts/ci/publish_mods.js
@@ -438,9 +438,12 @@ async function main() {
     }
 
     if (dryRun) {
+      const changelogText = getChangelogText(modName, cur.version);
       console.log(
         `  Dry run: would resolve file_group_id from API for mod_id=${cur.mod_id}`,
       );
+      console.log(`  Dry run: would publish changelog for ${cur.version}:`);
+      console.log(changelogText);
       uploaded.push(modName);
       continue;
     }

--- a/scripts/ci/publish_mods.js
+++ b/scripts/ci/publish_mods.js
@@ -144,9 +144,7 @@ async function resolveFileGroupId(modId, apiKey) {
 
 function getChangelogText(modName, version) {
   const changelogPath = `${modName}/CHANGELOG.md`;
-  if (!fs.existsSync(changelogPath)) {
-    throw new Error(`Missing ${changelogPath}; add a ## ${version} entry before publishing`);
-  }
+  if (!fs.existsSync(changelogPath)) return null;
 
   const lines = fs
     .readFileSync(changelogPath, "utf8")
@@ -155,9 +153,7 @@ function getChangelogText(modName, version) {
     const match = line.match(/^#{1,6}\s+(.+?)\s*#*$/);
     return match && match[1] === version;
   });
-  if (headingIndex === -1) {
-    throw new Error(`Missing ## ${version} heading in ${changelogPath}`);
-  }
+  if (headingIndex === -1) return null;
 
   const section = [];
   for (let i = headingIndex + 1; i < lines.length; i += 1) {
@@ -166,10 +162,7 @@ function getChangelogText(modName, version) {
   }
 
   const changelogText = section.join("\n").trim();
-  if (!changelogText) {
-    throw new Error(`Empty ## ${version} section in ${changelogPath}`);
-  }
-  return changelogText;
+  return changelogText || null;
 }
 
 async function publishChangelog(nexusModId, version, changelogText, apiKey) {
@@ -442,8 +435,10 @@ async function main() {
       console.log(
         `  Dry run: would resolve file_group_id from API for mod_id=${cur.mod_id}`,
       );
-      console.log(`  Dry run: would publish changelog for ${cur.version}:`);
-      console.log(changelogText);
+      if (changelogText) {
+        console.log(`  Dry run: would publish changelog for ${cur.version}:`);
+        console.log(changelogText);
+      }
       uploaded.push(modName);
       continue;
     }
@@ -490,7 +485,9 @@ async function main() {
         fileGroupId,
         apiKey,
       );
-      await publishChangelog(nexusModId, cur.version, changelogText, apiKey);
+      if (changelogText) {
+        await publishChangelog(nexusModId, cur.version, changelogText, apiKey);
+      }
       uploaded.push(modName);
     } catch (e) {
       console.error(`Error uploading ${modName}: ${e.message}`);

--- a/scripts/ci/publish_mods.js
+++ b/scripts/ci/publish_mods.js
@@ -213,13 +213,9 @@ function getChangedModFiles(before, sha) {
 }
 
 function zipMod(modName) {
-  const result = spawnSync(
-    "zip",
-    ["-r", `${modName}.zip`, modName, `-x`, `${modName}/CHANGELOG.md`],
-    {
-      encoding: "utf8",
-    },
-  );
+  const result = spawnSync("zip", ["-r", `${modName}.zip`, modName], {
+    encoding: "utf8",
+  });
   return result.status === 0 && fs.existsSync(`${modName}.zip`);
 }
 

--- a/scripts/ci/publish_mods.js
+++ b/scripts/ci/publish_mods.js
@@ -489,10 +489,16 @@ async function main() {
         fileGroupId,
         apiKey,
       );
-      if (changelogText) {
-        await publishChangelog(nexusModId, cur.version, changelogText, apiKey);
-      }
       uploaded.push(modName);
+      if (changelogText) {
+        try {
+          await publishChangelog(nexusModId, cur.version, changelogText, apiKey);
+        } catch (e) {
+          console.error(
+            `Warning: failed to publish ${modName} changelog: ${e.message}`,
+          );
+        }
+      }
     } catch (e) {
       console.error(`Error uploading ${modName}: ${e.message}`);
     }


### PR DESCRIPTION
## Summary
- Read the matching version section from each mod's CHANGELOG.md.
- Publish that text to Nexus Mods after a successful file upload.
- Document the per-mod changelog format.

## Validation
- node scripts/ci/publish_mods.js --dry-run