### PR TITLE
Update ProfilePictures Steam profile endpoint

### DIFF
--- a/ProfilePictures/ProfilePictures.mod
+++ b/ProfilePictures/ProfilePictures.mod
@@ -9,6 +9,6 @@ return {
 		})
 	end,
 	packages = {},
-	version = "26.08.08",
+	version = "26.08.11",
 	mod_id = "275",
 }

--- a/ProfilePictures/scripts/mods/ProfilePictures/ProfilePictures.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/ProfilePictures.lua
@@ -25,7 +25,7 @@ function mod.load_profile_image(player_info, cb)
 
 	if platform == "steam" then
 		xuid = Application.hex64_to_dec(player_info:platform_user_id())
-		url = "https://steam-profile-json.deno.dev/" .. xuid
+		url = "https://steam-profile-xml-to-json.dnrvs.workers.dev/" .. xuid
 		get_image_url = function(response)
 			return response.body.profile.avatarFull
 		end


### PR DESCRIPTION
## Summary
- Replace the retired deno.dev Steam profile endpoint with the Cloudflare Workers endpoint.
- Bump ProfilePictures to version 26.08.11.

## Verification
- Confirmed the committed diff contains only the endpoint and version changes.
- Confirmed no references to the old deno.dev endpoint remain in Lua files.