### PR TITLE
Fix ProfilePictures presence race and cover lobby and end screen

### DIFF
--- a/ProfilePictures/scripts/mods/ProfilePictures/EndScreen.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/EndScreen.lua
@@ -1,0 +1,49 @@
+local mod = get_mod("ProfilePictures")
+
+-- The end of mission portrait is a render target fed into the frame material's icon slot, so the picture goes into that same slot instead of being drawn over the panel. The equipped frame keeps rendering around it.
+local function _apply_profile_image(widget, texture)
+	local style = widget and widget.style.character_portrait
+
+	if not style then
+		return
+	end
+
+	local material_values = style.material_values
+
+	material_values.use_placeholder_texture = 0
+	material_values.rows = 1
+	material_values.columns = 1
+	material_values.grid_index = 0
+	material_values.texture_icon = texture
+	widget.dirty = true
+end
+
+mod:hook_safe("EndView", "_load_portrait_icon", function(_self, widget, _profile)
+	local widget_content = widget.content
+	local player_info = widget_content.player_info
+
+	mod.load_profile_image(player_info, function(texture)
+		-- Panels are rebuilt when the slots are reassigned, so a late callback may belong to another player
+		if widget_content.player_info ~= player_info then
+			return
+		end
+
+		widget_content.profile_picture_texture = texture
+
+		_apply_profile_image(widget, texture)
+	end)
+end)
+
+-- Vanilla replaces the icon slot with the character render target once it finishes loading
+mod:hook_safe("EndView", "_cb_set_player_icon", function(_self, widget)
+	local texture = widget.content.profile_picture_texture
+
+	if texture then
+		_apply_profile_image(widget, texture)
+	end
+end)
+
+-- Runs when a panel drops its portrait, so a rebuilt panel never keeps the previous player's picture
+mod:hook_safe("EndView", "_unload_portrait_icon", function(_self, widget)
+	widget.content.profile_picture_texture = nil
+end)

--- a/ProfilePictures/scripts/mods/ProfilePictures/Lobby.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/Lobby.lua
@@ -1,88 +1,49 @@
--- This doesn't work because the lobby doesn't recieve any social information about the players.
-
 local mod = get_mod("ProfilePictures")
-local UIWidget = require("scripts/managers/ui/ui_widget")
+
+-- The lobby portrait is a render target fed into the frame material's icon slot, so the picture goes into that same slot instead of being drawn over the panel. The equipped frame keeps rendering around it.
+local function _apply_profile_image(widget, texture)
+	local style = widget and widget.style.character_portrait
+
+	if not style then
+		return
+	end
+
+	local material_values = style.material_values
+
+	material_values.use_placeholder_texture = 0
+	material_values.rows = 1
+	material_values.columns = 1
+	material_values.grid_index = 0
+	material_values.texture_icon = texture
+	widget.dirty = true
+end
 
 mod:hook_safe("LobbyView", "_assign_player_to_slot", function(_self, player, slot)
+	local unique_id = slot.unique_id
 	local player_info = mod.player_info_for_player(player)
-	local widget = slot.panel_widget
+
 	mod.load_profile_image(player_info, function(texture)
-		widget.style.profile.material_values.texture_map = texture
-		widget.dirty = true
+		-- Slots get reset and reassigned, so a late callback may belong to a player who left
+		if slot.unique_id ~= unique_id then
+			return
+		end
+
+		slot.profile_picture_texture = texture
+
+		_apply_profile_image(slot.panel_widget, texture)
 	end)
 end)
 
-mod:hook_safe("LobbyView", "_cb_set_player_frame", function(_self, widget, item)
-	widget.style.frame.material_values.texture_map = item.icon
+-- Vanilla replaces the icon slot with the character render target once it finishes loading
+mod:hook_safe("LobbyView", "_cb_set_player_icon", function(_self, slot)
+	local texture = slot.profile_picture_texture
+
+	if texture then
+		_apply_profile_image(slot.panel_widget, texture)
+	end
 end)
 
-mod:hook_require("scripts/ui/views/lobby_view/lobby_view_definitions", function(instance)
-	local panel_definition = instance.panel_definition
-
-	-- if not panel_definition.content.frame then
-	local original_size = panel_definition.style.character_portrait.size
-	local size = { original_size[1] - 20, original_size[2] - 20 }
-
-	UIWidget.add_definition_pass(panel_definition, {
-		style_id = "frame",
-		value_id = "frame",
-		pass_type = "texture",
-		style = {
-			material_values = {
-				use_placeholder_texture = 0,
-				texture_map = "content/ui/textures/nameplates/portrait_frames/default",
-			},
-			horizontal_alignment = "center",
-			color = {
-				255,
-				255,
-				255,
-				255,
-			},
-			offset = {
-				0,
-				0,
-				10,
-			},
-			size = original_size,
-		},
-		visibility_function = function(_content, style)
-			if style.material_values.texture_map then
-				return true
-			end
-
-			return false
-		end,
-	})
-	UIWidget.add_definition_pass(panel_definition, {
-		style_id = "profile",
-		value_id = "profile",
-		pass_type = "texture",
-		style = {
-			material_values = {
-				use_placeholder_texture = 0,
-			},
-			horizontal_alignment = "center",
-			color = {
-				255,
-				255,
-				255,
-				255,
-			},
-			offset = {
-				0,
-				10,
-				1,
-			},
-			size = size,
-		},
-		visibility_function = function(_content, style)
-			if style.material_values.texture_map then
-				return true
-			end
-
-			return false
-		end,
-	})
-	-- end
+-- Runs at the start of every portrait load, so a reused slot never keeps the previous player's picture
+mod:hook_safe("LobbyView", "_unload_portrait_icon", function(_self, slot)
+	slot.profile_picture_texture = nil
 end)

--- a/ProfilePictures/scripts/mods/ProfilePictures/PlayerPanel.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/PlayerPanel.lua
@@ -1,26 +1,4 @@
 local mod = get_mod("ProfilePictures")
-local UIWidget = require("scripts/managers/ui/ui_widget")
-
-local function _load_portrait_icon(self)
-	local player = self._player
-	local player_info = mod.player_info_for_player(player)
-	mod.load_profile_image(player_info, function(texture)
-		if self.__deleted or self.destroyed or self._player ~= player then
-			return
-		end
-
-		local widgets_by_name = self._widgets_by_name
-		local widget = widgets_by_name and widgets_by_name.player_icon
-		if widget then
-			local style = widget.style.profile
-			if style then
-				local material_values = style.material_values
-				material_values.texture_map = texture
-				widget.dirty = true
-			end
-		end
-	end)
-end
 
 local hud_types = {
 	"PersonalPlayerPanel",
@@ -29,128 +7,59 @@ local hud_types = {
 	"TeamPlayerPanelHub",
 }
 
-for _, hud_type in ipairs(hud_types) do
-	mod:hook_safe("HudElement" .. hud_type, "_load_portrait_icon", _load_portrait_icon)
-end
+-- The portrait is a render target fed into the frame material's icon slot, so the picture goes into that same slot instead of being drawn over the panel. The equipped frame keeps rendering around it, and the panel's own tint, shadowing and fades still apply.
+local function _apply_profile_image(self, texture)
+	local widgets_by_name = self._widgets_by_name
+	local widget = widgets_by_name and widgets_by_name.player_icon
+	local style = widget and widget.style.texture
 
-local function _cb_set_player_frame(self, item)
-	if self.__deleted then
+	if not style then
 		return
 	end
 
-	local icon = nil
+	local material_values = style.material_values
 
-	if item.icon then
-		icon = item.icon
-	else
-		icon = "content/ui/textures/nameplates/portrait_frames/default"
-	end
+	material_values.use_placeholder_texture = 0
+	material_values.rows = 1
+	material_values.columns = 1
+	material_values.grid_index = 0
+	material_values.texture_icon = texture
+	widget.dirty = true
+end
 
-	local widget = self._widgets_by_name.player_icon
-	if widget.style.frame then
-		local material_values = widget.style.frame.material_values
-		material_values.texture_map = icon
-		widget.dirty = true
+local function _load_portrait_icon(self)
+	local player = self._player
+	local player_info = mod.player_info_for_player(player)
+
+	mod.load_profile_image(player_info, function(texture)
+		if self.__deleted or self.destroyed or self._player ~= player then
+			return
+		end
+
+		self._profile_picture_texture = texture
+
+		_apply_profile_image(self, texture)
+	end)
+end
+
+-- Vanilla replaces the icon slot with the character render target once it finishes loading
+local function _cb_set_player_icon(self)
+	local texture = self._profile_picture_texture
+
+	if texture then
+		_apply_profile_image(self, texture)
 	end
+end
+
+-- Runs at the start of every portrait load, so the previous player's picture never carries over
+local function _unload_portrait_icon(self)
+	self._profile_picture_texture = nil
 end
 
 for _, hud_type in ipairs(hud_types) do
-	mod:hook_safe("HudElement" .. hud_type, "_cb_set_player_frame", _cb_set_player_frame)
-end
+	local class_name = "HudElement" .. hud_type
 
-local function _unload_portrait_frame(func, self, ...)
-	local widgets_by_name = self._widgets_by_name
-	local widget = widgets_by_name and widgets_by_name.player_icon
-	local frame = widget and widget.style and widget.style.frame
-
-	if frame and frame.material_values then
-		frame.material_values.texture_map = nil
-		widget.dirty = true
-	end
-
-	return func(self, ...)
-end
-
-for _, hud_type in ipairs(hud_types) do
-	mod:hook("HudElement" .. hud_type, "_unload_portrait_frame", _unload_portrait_frame)
-end
-
-local function modify_player_icon_widget(instance)
-	local scenegraph_definition = instance.scenegraph_definition
-	local panel_size = scenegraph_definition.player_icon.size
-	local size = {
-		panel_size[1] - 20,
-		panel_size[2] - 20,
-	}
-	if not instance.widget_definitions.player_icon.content.frame then
-		UIWidget.add_definition_pass(instance.widget_definitions.player_icon, {
-			style_id = "frame",
-			value_id = "frame",
-			pass_type = "texture",
-			style = {
-				material_values = {
-					use_placeholder_texture = 0,
-					texture_map = "content/ui/textures/nameplates/portrait_frames/default",
-				},
-				color = {
-					255,
-					255,
-					255,
-					255,
-				},
-				offset = {
-					0,
-					0,
-					10,
-				},
-			},
-			visibility_function = function(_content, style)
-				if style.material_values.texture_map then
-					return true
-				end
-
-				return false
-			end,
-		})
-		UIWidget.add_definition_pass(instance.widget_definitions.player_icon, {
-			style_id = "profile",
-			value_id = "profile",
-			pass_type = "texture",
-			style = {
-				material_values = {
-					use_placeholder_texture = 0,
-				},
-				color = {
-					255,
-					255,
-					255,
-					255,
-				},
-				offset = {
-					10,
-					10,
-					1,
-				},
-				size = size,
-			},
-			visibility_function = function(_content, style)
-				if style.material_values.texture_map then
-					return true
-				end
-
-				return false
-			end,
-		})
-	end
-end
-
-local definitions = {
-	"scripts/ui/hud/elements/personal_player_panel/hud_element_personal_player_panel_definitions",
-	"scripts/ui/hud/elements/personal_player_panel_hub/hud_element_personal_player_panel_hub_definitions",
-	"scripts/ui/hud/elements/team_player_panel/hud_element_team_player_panel_definitions",
-	"scripts/ui/hud/elements/team_player_panel_hub/hud_element_team_player_panel_hub_definitions",
-}
-
-for _, definition in ipairs(definitions) do
-	mod:hook_require(definition, modify_player_icon_widget)
+	mod:hook_safe(class_name, "_load_portrait_icon", _load_portrait_icon)
+	mod:hook_safe(class_name, "_cb_set_player_icon", _cb_set_player_icon)
+	mod:hook_safe(class_name, "_unload_portrait_icon", _unload_portrait_icon)
 end

--- a/ProfilePictures/scripts/mods/ProfilePictures/ProfilePictures.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/ProfilePictures.lua
@@ -2,6 +2,9 @@ local mod = get_mod("ProfilePictures")
 
 local cache = mod:persistent_table("cache")
 
+-- Profile requests in flight, keyed by url. Deliberately not persistent: a reload leaves the promises behind.
+local pending_requests = {}
+
 local string_byte = string.byte
 local string_find = string.find
 local string_format = string.format
@@ -90,7 +93,30 @@ local function _image_proxy_prefix()
 	return _proxy_url_prefix_cache
 end
 
-local function _load_texture(image_url, fallback_image_url, cache_key, cb)
+local function _steam_image_url(response)
+	local body = response and response.body
+	local profile = body and body.profile
+	local avatar_url = profile and profile.avatarFull
+
+	if type(avatar_url) ~= "string" or avatar_url == "" then
+		return nil
+	end
+
+	return _steam_avatar_urls(avatar_url)
+end
+
+local function _xbox_image_url(response)
+	local body = response and response.body
+	local gamerpic = body and body.gamerpic
+
+	if type(gamerpic) ~= "string" or gamerpic == "" then
+		return nil
+	end
+
+	return gamerpic
+end
+
+local function _load_texture(image_url, fallback_image_url, cache_key, callbacks)
 	-- Public urls on third party CDNs, so don't attach the backend auth token
 	Managers.url_loader
 		:load_texture(image_url, false)
@@ -98,11 +124,14 @@ local function _load_texture(image_url, fallback_image_url, cache_key, cb)
 			local texture = data.texture
 
 			cache[cache_key] = texture
-			cb(texture)
+
+			for i = 1, #callbacks do
+				callbacks[i](texture)
+			end
 		end)
 		:catch(function(_error)
 			if fallback_image_url then
-				_load_texture(fallback_image_url, nil, cache_key, cb)
+				_load_texture(fallback_image_url, nil, cache_key, callbacks)
 
 				return
 			end
@@ -123,11 +152,8 @@ function mod.player_info_for_player(player)
 	return player_info
 end
 
-function mod.load_profile_image(player_info, cb)
-	if not player_info then
-		return
-	end
-
+-- The platform is resolved lazily through presence, so an account we are the first to ask about reports "" until the stream delivers. Retry once when the first update lands.
+local function _load_profile_image(player_info, cb, allow_retry)
 	local platform = player_info:platform()
 
 	local xuid, url, get_image_url
@@ -135,32 +161,32 @@ function mod.load_profile_image(player_info, cb)
 	if platform == "steam" then
 		xuid = Application.hex64_to_dec(player_info:platform_user_id())
 		url = "https://steam-profile-xml-to-json.dnrvs.workers.dev/" .. xuid
-		get_image_url = function(response)
-			local body = response and response.body
-			local profile = body and body.profile
-			local avatar_url = profile and profile.avatarFull
-
-			if type(avatar_url) ~= "string" or avatar_url == "" then
-				return nil
-			end
-
-			return _steam_avatar_urls(avatar_url)
-		end
+		get_image_url = _steam_image_url
 	end
 
 	if platform == "xbox" then
 		xuid = Application.hex64_to_dec(player_info:platform_user_id())
 		url = "https://xboxapi-workers.dnrvs.workers.dev/profiles/" .. xuid
-		get_image_url = function(response)
-			local body = response and response.body
-			local gamerpic = body and body.gamerpic
+		get_image_url = _xbox_image_url
+	end
 
-			if type(gamerpic) ~= "string" or gamerpic == "" then
-				return nil
-			end
+	if not (url and get_image_url) then
+		if allow_retry and player_info:account_id() then
+			player_info
+				:first_update_promise()
+				:next(function()
+					_load_profile_image(player_info, cb, false)
+				end)
+				:catch(function(_error)
+					mod:info("Presence lookup failed, no profile image")
+				end)
 
-			return gamerpic
+			return
 		end
+
+		mod:info("No profile image for platform '%s'", platform)
+
+		return
 	end
 
 	if cache[url] then
@@ -168,34 +194,63 @@ function mod.load_profile_image(player_info, cb)
 		return
 	end
 
-	if url and get_image_url then
-		Managers.backend
-			:url_request(url)
-			:next(function(profile_res)
-				local image_url, fallback_image_url = get_image_url(profile_res)
+	local pending = pending_requests[url]
 
-				if not image_url then
-					mod:info("No profile image in response from '%s'", url)
+	-- Several panels ask for the same player at once, so join a request that is already running. A cancelled promise never runs its handlers, so check that this one is still alive rather than waiting on it forever.
+	if pending and pending.promise and pending.promise:is_pending() then
+		local callbacks = pending.callbacks
 
-					return
-				end
+		callbacks[#callbacks + 1] = cb
 
-				local proxy_url = _image_proxy_prefix()
-
-				-- With a proxy configured, try it first and fall back to loading directly
-				if proxy_url then
-					fallback_image_url = image_url
-					image_url = _proxied_url(proxy_url, image_url)
-				end
-
-				_load_texture(image_url, fallback_image_url, url, cb)
-			end)
-			:catch(function(_error)
-				mod:info("Failed to request profile from '%s'", url)
-			end)
+		return
 	end
+
+	local request = {
+		callbacks = {
+			cb,
+		},
+	}
+
+	pending_requests[url] = request
+	request.promise = Managers.backend
+		:url_request(url)
+		:next(function(profile_res)
+			pending_requests[url] = nil
+
+			local image_url, fallback_image_url = get_image_url(profile_res)
+
+			if not image_url then
+				mod:info("No profile image in response from '%s'", url)
+
+				return
+			end
+
+			local proxy_url = _image_proxy_prefix()
+
+			-- With a proxy configured, try it first and fall back to loading directly
+			if proxy_url then
+				fallback_image_url = image_url
+				image_url = _proxied_url(proxy_url, image_url)
+			end
+
+			_load_texture(image_url, fallback_image_url, url, request.callbacks)
+		end)
+		:catch(function(_error)
+			pending_requests[url] = nil
+
+			mod:info("Failed to request profile from '%s'", url)
+		end)
+end
+
+function mod.load_profile_image(player_info, cb)
+	if not player_info then
+		return
+	end
+
+	_load_profile_image(player_info, cb, true)
 end
 
 mod:io_dofile("ProfilePictures/scripts/mods/ProfilePictures/PlayerPanel")
 mod:io_dofile("ProfilePictures/scripts/mods/ProfilePictures/SocialMenu")
--- mod:io_dofile("ProfilePictures/scripts/mods/ProfilePictures/Lobby") -- Doesn't work
+mod:io_dofile("ProfilePictures/scripts/mods/ProfilePictures/Lobby")
+mod:io_dofile("ProfilePictures/scripts/mods/ProfilePictures/EndScreen")

--- a/ProfilePictures/scripts/mods/ProfilePictures/SocialMenu.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/SocialMenu.lua
@@ -1,127 +1,60 @@
 local mod = get_mod("ProfilePictures")
 
-mod:hook_safe("SocialMenuRosterView", "_load_widget_portrait", function(_self, widget, _profile)
-	local content = widget.content
-	local player_info = content.player_info
-	mod.load_profile_image(player_info, function(texture)
-		local material_values = widget.style.profile.material_values
-		material_values.texture_map = texture
-		widget.dirty = true
-	end)
-end)
+-- The plaque portrait is a render target fed into the frame material's icon slot, so the picture goes into that same slot instead of being drawn over the plaque. The equipped frame keeps rendering around it.
+local function _apply_profile_image(widget, texture)
+	local style = widget.style.portrait
 
--- Reuse the frame texture when it gets loaded
-mod:hook_safe("SocialMenuRosterView", "_cb_set_player_frame", function(_self, widget, item)
-	local widget_content = widget.content
-	local profile = widget_content.player_info:profile()
-	local loadout = profile and profile.loadout
-	local frame_item = loadout and loadout.slot_portrait_frame
-	local frame_item_gear_id = frame_item and frame_item.gear_id
-	local icon = nil
-
-	if frame_item_gear_id == item.gear_id then
-		icon = item.icon
-	end
-
-	if not icon then
+	if not style then
 		return
 	end
 
-	local portrait_style = widget.style.frame
-	portrait_style.material_values.texture_map = icon
+	local material_values = style.material_values
+
+	material_values.use_placeholder_texture = 0
+	material_values.rows = 1
+	material_values.columns = 1
+	material_values.grid_index = 0
+	material_values.texture_icon = texture
 	widget.dirty = true
+end
+
+local function _load_profile_image(widget, player_info)
+	mod.load_profile_image(player_info, function(texture)
+		-- Roster widgets are recycled, so a late callback may belong to a player this widget no longer shows
+		if widget.content.player_info ~= player_info then
+			return
+		end
+
+		widget.content.profile_picture_texture = texture
+
+		_apply_profile_image(widget, texture)
+	end)
+end
+
+mod:hook_safe("SocialMenuRosterView", "_load_widget_portrait", function(_self, widget, _profile)
+	_load_profile_image(widget, widget.content.player_info)
 end)
 
--- Stop using the frame texture before it gets unloaded
-mod:hook("SocialMenuRosterView", "_queue_icons_for_unload", function(func, self, widget)
-	local portrait_style = widget.style.frame
-	if portrait_style then
-		portrait_style.material_values.texture_map = nil
+-- Vanilla replaces the icon slot with the character render target once it finishes loading
+mod:hook_safe("SocialMenuRosterView", "_cb_set_player_icon", function(_self, widget)
+	local texture = widget.content.profile_picture_texture
+
+	if texture then
+		_apply_profile_image(widget, texture)
 	end
-	return func(self, widget)
+end)
+
+-- Runs at the start of every portrait load, so a recycled widget never keeps the previous player's picture
+mod:hook_safe("SocialMenuRosterView", "_unload_widget_portrait", function(_self, widget)
+	widget.content.profile_picture_texture = nil
 end)
 
 mod:hook_require("scripts/ui/views/social_menu_roster_view/social_menu_roster_view_blueprints", function(instance)
-	local blueprint = instance.player_plaque
-
-	if not table.find_by_key(blueprint.pass_template, "style_id", "profile") then
-		table.insert(blueprint.pass_template, {
-			style_id = "frame",
-			value_id = "frame",
-			pass_type = "texture",
-			visibility_function = function(_content, style)
-				if style.material_values.texture_map then
-					return true
-				end
-
-				return false
-			end,
-		})
-
-		table.insert(blueprint.pass_template, {
-			style_id = "profile",
-			value_id = "profile",
-			pass_type = "texture",
-			visibility_function = function(_content, style)
-				if style.material_values.texture_map then
-					return true
-				end
-
-				return false
-			end,
-		})
-	end
-
 	mod:hook_safe(
-		blueprint,
+		instance.player_plaque,
 		"init",
 		function(_parent, widget, player_info, _callback_name, _secondary_callback_name, _ui_renderer)
-			mod.load_profile_image(player_info, function(texture)
-				local material_values = widget.style.profile.material_values
-				material_values.texture_map = texture
-				widget.dirty = true
-			end)
+			_load_profile_image(widget, player_info)
 		end
 	)
-
-	local orig_size = blueprint.style.portrait.size
-	local size = { orig_size[1] - 20, orig_size[2] - 20 }
-
-	table.merge_recursive(blueprint.style, {
-		frame = {
-			material_values = {
-				use_placeholder_texture = 0,
-				texture_map = "content/ui/textures/nameplates/portrait_frames/default",
-			},
-			color = {
-				255,
-				255,
-				255,
-				255,
-			},
-			offset = {
-				0,
-				0,
-				10,
-			},
-			size = orig_size,
-		},
-		profile = {
-			material_values = {
-				use_placeholder_texture = 0,
-			},
-			color = {
-				255,
-				255,
-				255,
-				255,
-			},
-			offset = {
-				10,
-				10,
-				1,
-			},
-			size = size,
-		},
-	})
 end)


### PR DESCRIPTION
mod.load_profile_image read player_info:platform() synchronously, but presence resolves it lazily and reports "" until the stream delivers. So whenever the mod was the first thing to ask about an account, neither endpoint matched, and the load gave up without requesting anything and without logging. Retry once on PlayerInfo:first_update_promise(), which is already resolved when presence is warm, and log when giving up.

That race was the whole reason Lobby.lua was disabled with "Doesn't work"; re-enable it, and add EndScreen.lua for the end of mission panels.

Rework how the picture is drawn. The old overlay put a flat texture over the portrait and rebuilt the frame on top from item.icon, which is nil for current frame items, so equipped modern frames rendered as the default everywhere. Vanilla feeds the portrait render target into the frame material's texture_icon slot, so put the picture in that same slot instead: the equipped frame keeps rendering around it for both icon_material and legacy icon items, and each panel's own tint and shadowing now apply to the picture as well. This also removes both added passes and their per-draw visibility functions from every portrait widget, including one per social roster plaque.

Every surface is now the same three hooks: start the load, re-apply after vanilla writes the render target, and clear on unload, with a staleness guard so a reused panel never shows the previous player's picture.

Hoist the two response parsers to file scope, and join profile requests that are already in flight instead of issuing a second one, guarding on the promise still being pending so a cancelled request cannot strand its callbacks.

Closes #214