### PR TITLE
Cover the ProfilePictures social popup header and Find Player result

### DIFF
--- a/ProfilePictures/scripts/mods/ProfilePictures/SocialMenu.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/SocialMenu.lua
@@ -19,13 +19,22 @@ local function _apply_profile_image(widget, texture)
 end
 
 local function _load_profile_image(widget, player_info)
+	local widget_content = widget.content
+
+	-- A widget kept for another player must not re-apply the previous picture when vanilla writes its render target
+	if widget_content.profile_picture_player_info ~= player_info then
+		widget_content.profile_picture_texture = nil
+	end
+
+	widget_content.profile_picture_player_info = player_info
+
 	mod.load_profile_image(player_info, function(texture)
-		-- Roster widgets are recycled, so a late callback may belong to a player this widget no longer shows
-		if widget.content.player_info ~= player_info then
+		-- Widgets are reused, so a late callback may belong to a player this widget no longer shows, or to a plaque the popup has torn down since
+		if widget_content.profile_picture_player_info ~= player_info then
 			return
 		end
 
-		widget.content.profile_picture_texture = texture
+		widget_content.profile_picture_texture = texture
 
 		_apply_profile_image(widget, texture)
 	end)
@@ -58,3 +67,76 @@ mod:hook_require("scripts/ui/views/social_menu_roster_view/social_menu_roster_vi
 		end
 	)
 end)
+
+-- The popup draws its header portrait itself instead of going through the roster view, both for a roster entry and for the Find Player search
+mod:hook_safe("ViewElementPlayerSocialPopup", "_set_player_info", function(self, _parent, player_info)
+	_load_profile_image(self._widgets_by_name.player_header, player_info)
+end)
+
+-- Runs when the shown player's profile changes
+mod:hook_safe("ViewElementPlayerSocialPopup", "_update_portrait", function(self)
+	_load_profile_image(self._widgets_by_name.player_header, self._player_info)
+end)
+
+-- Vanilla replaces the icon slot with the character render target once it finishes loading
+mod:hook_safe("ViewElementPlayerSocialPopup", "_cb_set_player_icon", function(_self, widget)
+	local texture = widget.content.profile_picture_texture
+
+	if texture then
+		_apply_profile_image(widget, texture)
+	end
+end)
+
+mod:hook_safe("ViewElementPlayerSocialPopup", "_cb_unset_player_icon", function(_self, widget)
+	widget.content.profile_picture_texture = nil
+end)
+
+-- One plaque serves every search, and the result only arrives once the friend code request comes back, so drop what the previous search was loading
+mod:hook_safe("ViewElementPlayerSocialPopup", "_search_for_player", function(self)
+	local widget = self._widgets_by_name.player_plaque
+
+	if not widget then
+		return
+	end
+
+	local widget_content = widget.content
+
+	widget_content.profile_picture_player_info = nil
+	widget_content.profile_picture_texture = nil
+end)
+
+-- The popup can go away with a request still in flight, so stop it from reaching the widgets it was started for
+mod:hook_safe("ViewElementPlayerSocialPopup", "destroy", function(self)
+	local widgets_by_name = self._widgets_by_name
+
+	if not widgets_by_name then
+		return
+	end
+
+	local header = widgets_by_name.player_header
+
+	if header then
+		header.content.profile_picture_player_info = nil
+	end
+
+	local plaque = widgets_by_name.player_plaque
+
+	if plaque then
+		plaque.content.profile_picture_player_info = nil
+	end
+end)
+
+mod:hook_require(
+	"scripts/ui/view_elements/view_element_player_social_popup/view_element_player_social_popup_blueprints",
+	function(instance)
+		mod:hook_safe(instance.player_plaque, "update", function(_parent, widget)
+			local widget_content = widget.content
+			local player_info = widget_content.player_info
+
+			-- The search result is assigned asynchronously, and vanilla only loads a portrait for it when the account resolves to a character profile
+			if widget_content.profile_picture_player_info ~= player_info then
+				_load_profile_image(widget, player_info)
+			end
+		end)
+	end
+)


### PR DESCRIPTION
The Find Player result plaque comes from view_element_player_social_popup_blueprints rather than the roster blueprints, but Darktide still runs it through SocialMenuRosterView:_load_widget_portrait, so the existing hooks already fired for it. The style.profile and style.frame errors #217 reports came from the old overlay passes and have been gone since 34eace9. What was left is that vanilla only calls _load_widget_portrait for the plaque when the account resolves to a character profile, which PlayerInfo:profile() falls back to presence for and cannot always produce, so those searches showed no picture at all.

Hook the popup blueprint's player_plaque update, the one place the asynchronously assigned player_info becomes observable, and start the load whenever the player behind the plaque changes. The equality gate means the profile-present path, where _load_widget_portrait already started the load, issues no second request, and the blueprint is only ever built for the Find Player content list.

The popup draws its header portrait itself instead of going through the roster view, so it kept showing the vanilla character render directly above a plaque showing an external picture. Give it the same three hooks as every other surface: start the load in _set_player_info and _update_portrait, re-apply in _cb_set_player_icon, clear in _cb_unset_player_icon.

One plaque serves every search and the popup can be destroyed with a request still in flight, so key the picture to a dedicated profile_picture_player_info instead of the widget's player_info, and drop it when a search starts and when the popup is destroyed. Clearing content.player_info instead would crash vanilla, which dereferences it unguarded in _update_portraits and leaves the plaque in _widgets_with_portraits. Also clear a cached picture whenever a widget is loaded for another player, so someone whose portrait was never loaded cannot leave their picture behind for the next one.

Closes #217