### PR TITLE
Cover the ProfilePictures Party Finder preview and own party slots

### DIFF
--- a/ProfilePictures/scripts/mods/ProfilePictures/EndScreen.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/EndScreen.lua
@@ -1,22 +1,6 @@
 local mod = get_mod("ProfilePictures")
 
--- The end of mission portrait is a render target fed into the frame material's icon slot, so the picture goes into that same slot instead of being drawn over the panel. The equipped frame keeps rendering around it.
-local function _apply_profile_image(widget, texture)
-	local style = widget and widget.style.character_portrait
-
-	if not style then
-		return
-	end
-
-	local material_values = style.material_values
-
-	material_values.use_placeholder_texture = 0
-	material_values.rows = 1
-	material_values.columns = 1
-	material_values.grid_index = 0
-	material_values.texture_icon = texture
-	widget.dirty = true
-end
+local _apply_profile_image = mod.apply_profile_image
 
 mod:hook_safe("EndView", "_load_portrait_icon", function(_self, widget, _profile)
 	local widget_content = widget.content
@@ -30,7 +14,7 @@ mod:hook_safe("EndView", "_load_portrait_icon", function(_self, widget, _profile
 
 		widget_content.profile_picture_texture = texture
 
-		_apply_profile_image(widget, texture)
+		_apply_profile_image(widget, "character_portrait", texture)
 	end)
 end)
 
@@ -39,7 +23,7 @@ mod:hook_safe("EndView", "_cb_set_player_icon", function(_self, widget)
 	local texture = widget.content.profile_picture_texture
 
 	if texture then
-		_apply_profile_image(widget, texture)
+		_apply_profile_image(widget, "character_portrait", texture)
 	end
 end)
 

--- a/ProfilePictures/scripts/mods/ProfilePictures/GroupFinder.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/GroupFinder.lua
@@ -1,0 +1,136 @@
+local mod = get_mod("ProfilePictures")
+
+local _apply_profile_image = mod.apply_profile_image
+
+local TEAM_MEMBER_WIDGET_NAMES = {
+	"team_member_1",
+	"team_member_2",
+	"team_member_3",
+	"team_member_4",
+}
+
+-- Both Party Finder surfaces carry an account id rather than a PlayerInfo, so that is what the picture is keyed to
+local function _load_profile_image(widget, account_id)
+	local widget_content = widget.content
+
+	-- A widget kept for another player must not re-apply the previous picture when vanilla writes its render target
+	if widget_content.profile_picture_account_id ~= account_id then
+		widget_content.profile_picture_texture = nil
+	end
+
+	widget_content.profile_picture_account_id = account_id
+
+	if not account_id then
+		return
+	end
+
+	local social_service_manager = Managers.data_service.social
+	local player_info = social_service_manager and social_service_manager:get_player_info_by_account_id(account_id)
+
+	mod.load_profile_image(player_info, function(texture)
+		-- Grid entries are recycled and party slots reassigned, so a late callback may belong to a player this widget no longer shows
+		if widget_content.profile_picture_account_id ~= account_id then
+			return
+		end
+
+		widget_content.profile_picture_texture = texture
+
+		_apply_profile_image(widget, "character_portrait", texture)
+	end)
+end
+
+-- Dropping the account id is what keeps a request in flight from reaching the widget it was started for
+local function _clear_profile_image(widget)
+	local widget_content = widget.content
+
+	widget_content.profile_picture_texture = nil
+	widget_content.profile_picture_account_id = nil
+end
+
+-- The previewed group's members and the incoming join requests both render through this blueprint
+mod:hook_require("scripts/ui/views/group_finder_view/group_finder_view_definitions", function(instance)
+	local grid_blueprints = instance.grid_blueprints
+	local blueprint = grid_blueprints and grid_blueprints.player_request_entry
+
+	if not blueprint then
+		return
+	end
+
+	mod:hook_safe(blueprint, "load_icon", function(_parent, widget, element)
+		local account_id = element and element.account_id
+
+		-- The grid re-runs this every frame while it scrolls, so only act once the entry changed player
+		if widget.content.profile_picture_account_id ~= account_id then
+			_load_profile_image(widget, account_id)
+		end
+	end)
+
+	-- Vanilla loads the portrait through a closure instead of a named method, so the entry's own update is the only place its render target landing in the icon slot is observable
+	mod:hook_safe(blueprint, "update", function(_parent, widget)
+		local texture = widget.content.profile_picture_texture
+
+		if not texture then
+			return
+		end
+
+		local style = widget.style.character_portrait
+
+		if style and style.material_values.texture_icon ~= texture then
+			_apply_profile_image(widget, "character_portrait", texture)
+		end
+	end)
+
+	-- Runs when an entry scrolls out of view
+	mod:hook_safe(blueprint, "unload_icon", function(_parent, widget)
+		_clear_profile_image(widget)
+	end)
+
+	-- Runs for every entry when the layout is rebuilt, which is what previewing another group does
+	mod:hook_safe(blueprint, "destroy", function(_parent, widget)
+		_clear_profile_image(widget)
+	end)
+end)
+
+-- The own party slots are filled here, and the account ids land on the listed group's members in the same pass
+mod:hook_safe("GroupFinderView", "_update_listed_group", function(self)
+	local widgets_by_name = self._widgets_by_name
+
+	if not widgets_by_name then
+		return
+	end
+
+	local own_group_visualization = self._own_group_visualization
+	local members = own_group_visualization and own_group_visualization.members
+
+	for i = 1, 4 do
+		local widget = widgets_by_name[TEAM_MEMBER_WIDGET_NAMES[i]]
+
+		if widget then
+			local member = members and members[i]
+			local account_id = member and member.account_id
+
+			-- Also runs while a party member's profile is still resolving, so only act once the slot changed player
+			if widget.content.profile_picture_account_id ~= account_id then
+				_load_profile_image(widget, account_id)
+			end
+		end
+	end
+end)
+
+-- Vanilla replaces the icon slot with the character render target once it finishes loading
+mod:hook_safe("GroupFinderView", "_cb_set_player_icon", function(_self, widget)
+	local texture = widget.content.profile_picture_texture
+
+	if texture then
+		_apply_profile_image(widget, "character_portrait", texture)
+	end
+end)
+
+mod:hook_safe("GroupFinderView", "_cb_unset_player_icon", function(_self, widget)
+	widget.content.profile_picture_texture = nil
+end)
+
+-- Runs before every refill and when the view closes, so a reused slot never keeps the previous player's picture
+mod:hook_safe("GroupFinderView", "_unload_portrait_icon", function(_self, widget)
+	_clear_profile_image(widget)
+end)

--- a/ProfilePictures/scripts/mods/ProfilePictures/Lobby.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/Lobby.lua
@@ -1,22 +1,6 @@
 local mod = get_mod("ProfilePictures")
 
--- The lobby portrait is a render target fed into the frame material's icon slot, so the picture goes into that same slot instead of being drawn over the panel. The equipped frame keeps rendering around it.
-local function _apply_profile_image(widget, texture)
-	local style = widget and widget.style.character_portrait
-
-	if not style then
-		return
-	end
-
-	local material_values = style.material_values
-
-	material_values.use_placeholder_texture = 0
-	material_values.rows = 1
-	material_values.columns = 1
-	material_values.grid_index = 0
-	material_values.texture_icon = texture
-	widget.dirty = true
-end
+local _apply_profile_image = mod.apply_profile_image
 
 mod:hook_safe("LobbyView", "_assign_player_to_slot", function(_self, player, slot)
 	local unique_id = slot.unique_id
@@ -30,7 +14,7 @@ mod:hook_safe("LobbyView", "_assign_player_to_slot", function(_self, player, slo
 
 		slot.profile_picture_texture = texture
 
-		_apply_profile_image(slot.panel_widget, texture)
+		_apply_profile_image(slot.panel_widget, "character_portrait", texture)
 	end)
 end)
 
@@ -39,7 +23,7 @@ mod:hook_safe("LobbyView", "_cb_set_player_icon", function(_self, slot)
 	local texture = slot.profile_picture_texture
 
 	if texture then
-		_apply_profile_image(slot.panel_widget, texture)
+		_apply_profile_image(slot.panel_widget, "character_portrait", texture)
 	end
 end)
 

--- a/ProfilePictures/scripts/mods/ProfilePictures/PlayerPanel.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/PlayerPanel.lua
@@ -1,5 +1,7 @@
 local mod = get_mod("ProfilePictures")
 
+local _apply_profile_image = mod.apply_profile_image
+
 local hud_types = {
 	"PersonalPlayerPanel",
 	"PersonalPlayerPanelHub",
@@ -7,24 +9,11 @@ local hud_types = {
 	"TeamPlayerPanelHub",
 }
 
--- The portrait is a render target fed into the frame material's icon slot, so the picture goes into that same slot instead of being drawn over the panel. The equipped frame keeps rendering around it, and the panel's own tint, shadowing and fades still apply.
-local function _apply_profile_image(self, texture)
+-- The player icon widget belongs to the panel, so resolve it before handing the picture over
+local function _apply_panel_profile_image(self, texture)
 	local widgets_by_name = self._widgets_by_name
-	local widget = widgets_by_name and widgets_by_name.player_icon
-	local style = widget and widget.style.texture
 
-	if not style then
-		return
-	end
-
-	local material_values = style.material_values
-
-	material_values.use_placeholder_texture = 0
-	material_values.rows = 1
-	material_values.columns = 1
-	material_values.grid_index = 0
-	material_values.texture_icon = texture
-	widget.dirty = true
+	_apply_profile_image(widgets_by_name and widgets_by_name.player_icon, "texture", texture)
 end
 
 local function _load_portrait_icon(self)
@@ -38,7 +27,7 @@ local function _load_portrait_icon(self)
 
 		self._profile_picture_texture = texture
 
-		_apply_profile_image(self, texture)
+		_apply_panel_profile_image(self, texture)
 	end)
 end
 
@@ -47,7 +36,7 @@ local function _cb_set_player_icon(self)
 	local texture = self._profile_picture_texture
 
 	if texture then
-		_apply_profile_image(self, texture)
+		_apply_panel_profile_image(self, texture)
 	end
 end
 

--- a/ProfilePictures/scripts/mods/ProfilePictures/ProfilePictures.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/ProfilePictures.lua
@@ -250,7 +250,26 @@ function mod.load_profile_image(player_info, cb)
 	_load_profile_image(player_info, cb, true)
 end
 
+-- The portrait is a render target fed into the frame material's icon slot, so the picture goes into that same slot instead of being drawn over the panel. The equipped frame keeps rendering around it, and each panel's own tint, shadowing and fades still apply.
+function mod.apply_profile_image(widget, style_id, texture)
+	local style = widget and widget.style[style_id]
+
+	if not style then
+		return
+	end
+
+	local material_values = style.material_values
+
+	material_values.use_placeholder_texture = 0
+	material_values.rows = 1
+	material_values.columns = 1
+	material_values.grid_index = 0
+	material_values.texture_icon = texture
+	widget.dirty = true
+end
+
 mod:io_dofile("ProfilePictures/scripts/mods/ProfilePictures/PlayerPanel")
 mod:io_dofile("ProfilePictures/scripts/mods/ProfilePictures/SocialMenu")
 mod:io_dofile("ProfilePictures/scripts/mods/ProfilePictures/Lobby")
 mod:io_dofile("ProfilePictures/scripts/mods/ProfilePictures/EndScreen")
+mod:io_dofile("ProfilePictures/scripts/mods/ProfilePictures/GroupFinder")

--- a/ProfilePictures/scripts/mods/ProfilePictures/SocialMenu.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/SocialMenu.lua
@@ -1,22 +1,6 @@
 local mod = get_mod("ProfilePictures")
 
--- The plaque portrait is a render target fed into the frame material's icon slot, so the picture goes into that same slot instead of being drawn over the plaque. The equipped frame keeps rendering around it.
-local function _apply_profile_image(widget, texture)
-	local style = widget.style.portrait
-
-	if not style then
-		return
-	end
-
-	local material_values = style.material_values
-
-	material_values.use_placeholder_texture = 0
-	material_values.rows = 1
-	material_values.columns = 1
-	material_values.grid_index = 0
-	material_values.texture_icon = texture
-	widget.dirty = true
-end
+local _apply_profile_image = mod.apply_profile_image
 
 local function _load_profile_image(widget, player_info)
 	local widget_content = widget.content
@@ -36,7 +20,7 @@ local function _load_profile_image(widget, player_info)
 
 		widget_content.profile_picture_texture = texture
 
-		_apply_profile_image(widget, texture)
+		_apply_profile_image(widget, "portrait", texture)
 	end)
 end
 
@@ -49,7 +33,7 @@ mod:hook_safe("SocialMenuRosterView", "_cb_set_player_icon", function(_self, wid
 	local texture = widget.content.profile_picture_texture
 
 	if texture then
-		_apply_profile_image(widget, texture)
+		_apply_profile_image(widget, "portrait", texture)
 	end
 end)
 
@@ -83,7 +67,7 @@ mod:hook_safe("ViewElementPlayerSocialPopup", "_cb_set_player_icon", function(_s
 	local texture = widget.content.profile_picture_texture
 
 	if texture then
-		_apply_profile_image(widget, texture)
+		_apply_profile_image(widget, "portrait", texture)
 	end
 end)
 


### PR DESCRIPTION
Party Finder renders portraits through two paths, neither of which goes near the SocialMenuRosterView or HUD methods the mod already hooks, so both kept showing the vanilla character render. The previewed group's members and the incoming join requests come from grid_blueprints.player_request_entry, and the four slots showing your own party in the advertising state are driven imperatively by GroupFinderView.

The issue asks for a separate profile texture pass, but that architecture was removed in 34eace9; the picture goes into the frame material's texture_icon slot now, so the equipped frame keeps rendering around it. Both Party Finder surfaces draw through style.character_portrait, the same style id Lobby and EndScreen already use.

The grid entries could not take the usual three hooks. Vanilla builds the blueprint's portrait callback as an anonymous closure inside load_icon, so there is no named method to hook for the step where vanilla writes its render target over the picture. The entry's own update is the only place that becomes observable, so re-apply from there, comparing against the texture already in the material so nothing is written per frame and the widget is never marked dirty for nothing. Same approach as the popup plaque in dad97f5.

Key the picture to the account id rather than a PlayerInfo. Both surfaces carry an account id directly and the grid entry never has a PlayerInfo at all. Dropping that id is what keeps a request in flight from reaching a widget, so unload_icon and destroy both clear it, and destroy runs for every entry when the layout is rebuilt, which is exactly what previewing another group does.

For the own party slots hook _update_listed_group rather than _load_portrait_icon. It is the sole caller of _request_player_icon, and by the time it returns the account ids have landed on the listed group's members aligned with the team_member widgets, so the profile table never has to be mapped back to a player. Both load paths are gated on the account actually changing, because the grid re-runs load_icon every frame while it scrolls and _update_listed_group re-runs while a party member's profile is still resolving.

Five copies of _apply_profile_image differing only in a style id was one too many, so hoist it to mod.apply_profile_image and pass the style id in. PlayerPanel keeps a small adapter because its callers hold the HUD element rather than a widget. This also gives the social menu the nil guard on the widget that its copy was the only one missing.

Closes #219