### PR TITLE
Accept a PlayerInfo as the ProfilePictures loadout preview player

### DIFF
--- a/ProfilePictures/scripts/mods/ProfilePictures/Inventory.lua
+++ b/ProfilePictures/scripts/mods/ProfilePictures/Inventory.lua
@@ -10,13 +10,30 @@ local function _apply_view_profile_image(self, texture)
 	_apply_profile_image(widgets_by_name and widgets_by_name.character_portrait, "texture_portrait", texture)
 end
 
+-- Vanilla always opens the view with a Player, but the mods that add an inspect button to Party Finder and the social menu pass the PlayerInfo they hold instead, which is already what the loader wants
+local function _preview_player_info(player)
+	if not player then
+		return
+	end
+
+	-- Every Player class defines this and PlayerInfo does not
+	if player.is_human_controlled then
+		return mod.player_info_for_player(player)
+	end
+
+	-- Only hand on something that really is a PlayerInfo, so an unexpected preview player loads nothing rather than erroring further in
+	if player.account_id then
+		return player
+	end
+end
+
 mod:hook_safe("InventoryBackgroundView", "_load_portrait_icon", function(self)
 	if not location_enabled.inventory then
 		return
 	end
 
 	local player = self._preview_player
-	local player_info = player and mod.player_info_for_player(player)
+	local player_info = _preview_player_info(player)
 
 	mod.load_profile_image(player_info, function(texture)
 		-- The view can go away with the request still in flight


### PR DESCRIPTION
Inspecting someone from Party Finder made the mod error every time the loadout screen requested a portrait, and the picture never loaded there. Inventory.lua fed InventoryBackgroundView._preview_player straight into mod.player_info_for_player, which calls is_human_controlled on it.

The assumption held for every vanilla path. _preview_player is context.player, and vanilla only ever fills that from PlayerCharacterOptionsView._on_inspect_pressed, which passes a real Player. InspectFromPartyFinder and InspectFromSocial only hold an account id, so they resolve it through the social service and pass the PlayerInfo instead. is_human_controlled is defined on HumanPlayer, RemotePlayer and BotPlayer but not on PlayerInfo, so the call came back nil and the error repeated on every inventory re-sync.

Branch on the shape in Inventory.lua rather than loosening player_info_for_player. Resolving a Player is what that function is for, and its other callers, the HUD player panels, the notification feed and the lobby, are never handed anything else. Inventory is the only surface that takes a preview player from whoever opened the view, so the tolerance belongs there.

Test is_human_controlled first, not account_id. HumanPlayer and RemotePlayer define account_id as well, so checking that first would misclassify a real Player and hand the loader something it cannot read a platform off. Once a Player is ruled out, account_id is a sound PlayerInfo marker: it is a class method, so its presence implies the platform, platform_user_id and first_update_promise that the loader goes on to call. Anything matching neither shape resolves to nil, so an unexpected preview player loads nothing instead of erroring further in.

Hand the PlayerInfo on rather than only bailing out, which is what makes the picture appear rather than merely silencing the error. It is already the object mod.load_profile_image wants, the same one GroupFinder and SocialMenu feed it, so the Party Finder case also picks up the first_update_promise retry for an account whose platform has not resolved from presence yet.

The late-callback guard needs no change. self._preview_player ~= player is an identity comparison and holds for a PlayerInfo exactly as for a Player, so a request still in flight when the view switches player or is destroyed is discarded as before.

Closes #231