### PR TITLE
Ungate the Healthbars vanilla boss bar indicators from the per-enemy …

### DIFF
--- a/Healthbars/scripts/mods/Healthbars/HealthbarMarker.lua
+++ b/Healthbars/scripts/mods/Healthbars/HealthbarMarker.lua
@@ -2044,27 +2044,6 @@ template.update_vanilla_boss_indicator = function(widget, target, dt)
 		return
 	end
 
-	local breed_features = mod._healthbar_breed_features
-	local features = breed_features and breed_features[breed.name]
-
-	if not features or features.enabled ~= true then
-		target.healthbars_vanilla_boss_indicator_state = nil
-		_hide_boss_indicator_widget(widget)
-
-		return
-	end
-
-	local full_debug_display = mod._psykhanium_full_debug_display == true
-	local show_dots = full_debug_display or features.show_dots == true
-	local show_debuffs = full_debug_display or features.show_debuffs == true
-
-	if not show_dots and not show_debuffs then
-		target.healthbars_vanilla_boss_indicator_state = nil
-		_hide_boss_indicator_widget(widget)
-
-		return
-	end
-
 	local buff_extension = ScriptUnit_has_extension(unit, "buff_system")
 
 	if not buff_extension then
@@ -2085,7 +2064,10 @@ template.update_vanilla_boss_indicator = function(widget, target, dt)
 	if state.debuff_check_timer >= 0.1 then
 		state.debuff_check_timer = 0
 
-		_poll_status_indicators(state.debuffs, state.content, buff_extension, unit, show_dots, show_debuffs)
+		-- Vanilla boss indicators ignore the per-enemy Healthbars feature settings; only
+		-- `show_vanilla_boss_bar_indicators` and the individual DoT/debuff toggles gate
+		-- what appears here.
+		_poll_status_indicators(state.debuffs, state.content, buff_extension, unit, true, true)
 	end
 
 	_pack_indicator_placements(state)


### PR DESCRIPTION
…settings

A player who had turned an enemy off in the Enemies settings stopped seeing DoT and debuff indicators on that enemy's vanilla boss health bar, with Show DoT/debuff markers on vanilla boss health bars still on. Every other enemy, Crushers included, kept working.

The per-enemy overhaul in 8eed23b gave update_vanilla_boss_indicator the same feature gate as the custom marker path: an early return on features.enabled, a second on neither show_dots nor show_debuffs being set, and the per-breed flags passed into _poll_status_indicators. Before that the function deliberately ignored the boss enemy display mode, and the comment that said so went with the change.

The migration is what makes this easy to hit. An old Disabled boss setting becomes enabled = false with show_healthbar, show_dots and show_debuffs all true, so anyone who had turned off the mod's own boss marker while keeping the indicators on the vanilla bar lands straight on the first early return.

Restore the two literals and the comment. The vanilla bar is a separate display from the mod's marker, so show_vanilla_boss_bar_indicators is the master switch for it and the individual DoT and debuff toggles decide what appears there. Passing true, true widens only the category gate: every entry in DEBUFF_DEFS carries a setting and _poll_status_indicators still runs _feature_enabled on it, so a disabled indicator stays hidden.

Full debug Psykhanium needs no local of its own. _feature_enabled already short-circuits on _psykhanium_full_debug_display, and the master switch at the top of the function still covers _inactive_outside_psykhanium and _psykhanium_vanilla_only, so full_debug_display goes with the gates it fed.

The deleted early returns also cleared healthbars_vanilla_boss_indicator_state; drop that with them. No early return did it before the regression, hide_existing_boss_indicators only ever touches widgets, and _poll_status_indicators clears state.debuffs on entry, so nothing stale survives a re-enable.

update_function is left alone. Disabling an enemy still removes its Healthbars marker; only the vanilla bar stops caring.

Closes #234