### PR TITLE
Fit the Healthbars vanilla boss bar indicators to stacked boss health…

### DIFF
--- a/Healthbars/scripts/mods/Healthbars/HealthbarMarker.lua
+++ b/Healthbars/scripts/mods/Healthbars/HealthbarMarker.lua
@@ -1881,7 +1881,7 @@ local function _poll_status_indicators(debuffs, poll_content, buff_extension, un
 	end
 end
 
-local function _pack_indicator_placements(state)
+local function _pack_indicator_placements(state, single_row)
 	local active_by_type = state._active_by_type
 	local active_debuffs = state._active_debuffs
 	local active_dots = state._active_dots
@@ -1918,6 +1918,36 @@ local function _pack_indicator_placements(state)
 		if debuff then
 			active_dots[#active_dots + 1] = debuff
 		end
+	end
+
+	if single_row then
+		-- Third-party mods can stack the boss bars in rows too close together for the
+		-- upper indicator row. Pack everything into the row nearest the bar instead
+		-- (slots GRID_COLS + 1 .. GRID_COLS * 2), DoTs first, then debuffs.
+		local last_slot = GRID_COLS * 2
+		local slot = GRID_COLS
+
+		for i = 1, #active_dots do
+			if slot >= last_slot then
+				break
+			end
+
+			slot = slot + 1
+			placement_slots[#placement_slots + 1] = slot
+			placement_debuffs[#placement_debuffs + 1] = active_dots[i]
+		end
+
+		for i = 1, #active_debuffs do
+			if slot >= last_slot then
+				break
+			end
+
+			slot = slot + 1
+			placement_slots[#placement_slots + 1] = slot
+			placement_debuffs[#placement_debuffs + 1] = active_debuffs[i]
+		end
+
+		return
 	end
 
 	-- Vanilla boss bars keep rows type-stable when both are present:
@@ -2070,7 +2100,11 @@ template.update_vanilla_boss_indicator = function(widget, target, dt)
 		_poll_status_indicators(state.debuffs, state.content, buff_extension, unit, true, true)
 	end
 
-	_pack_indicator_placements(state)
+	-- A non-zero widget Y offset means another mod moved this bar into a lower row, where
+	-- only the indicator row nearest the bar fits without covering the bar above it.
+	local widget_offset = widget.offset
+
+	_pack_indicator_placements(state, widget_offset ~= nil and widget_offset[2] ~= 0)
 	_apply_boss_indicator_placements(widget, state)
 
 	widget.visible = #state._placement_slots > 0


### PR DESCRIPTION
… bars

Recolor Boss Health Bars expands the boss HUD from the vanilla two bars to as many as twelve, and a player reported losing the DoT and debuff indicators when running it alongside Healthbars.

The widget plumbing was never the problem. Recolor builds each extra bar in a hook_safe on HudElementBossHealth._setup_widget_groups from table.clone(definitions.left_double_target_widget_definitions), taken off self._definitions at HUD element construction, which is long after mod:hook_require has injected healthbars_indicators. Fatshark's table.clone is a deep dup, and DMF applies file hooks retroactively to every past instance of a required file, so load order never mattered either. Recolor copies the group's row and column placement onto every widget it creates, ours included, and the update hook already reads self._max_health_bars rather than assuming two bars. Every extra bar was getting its own indicators.

What broke was the geometry. Recolor stacks rows 55 px apart, and a row already spends that on its toughness bar, health bar and name text, while the indicators sit 20 to 74 px above their own bar at z 100. Every row below the first painted its upper icon row straight across the health bar above it and its lower row across that bar's name.

Collapse the indicators to the single row nearest the bar for any bar another mod has moved down. widget.offset[2] is the test: UIWidget.create_definition never sets an offset, so UIWidget.init gives the three vanilla groups {0, 0, 0} and anything non-zero is another mod's doing. It needs no knowledge of Recolor, no cached layout state and no extra hook, and it is per widget rather than per element, so a bar still on the top row keeps both icon rows and Recolor at four columns and one line loses nothing.

The branch is an early return in _pack_indicator_placements, placed after the ordering loops and before the existing dot_slot_offset block, so the two-row path is untouched and vanilla layouts are unchanged. Slots 9 to 16 are the bar-adjacent row the code already uses for DoTs when no debuffs are present, so there are no new layout constants and no change to create_vanilla_boss_indicator_definition. _apply_boss_indicator_placements already clamps to max_slots_used and _clear_boss_indicator_slots already blanks all sixteen slots each frame, so the vacated upper row clears itself.

No lazy per-group widget creation, which the issue suggested: it would be dead code against Recolor 2.4 and could not be exercised. No load_after entry either, since compatibility is already order independent and adding one would advertise a dependency that does not exist.

Icons on the lower rows still overlap the name text of the row above by roughly 15 px. At 55 px spacing there are about 2 px of free vertical room per row, so no placement of 25 px icons is collision free.

Closes #235