### PR TITLE
Recalculate NumericUI HUD numbers on change instead of every frame

### DIFF
--- a/NumericUI/scripts/mods/NumericUI/BossHealth.lua
+++ b/NumericUI/scripts/mods/NumericUI/BossHealth.lua
@@ -2,6 +2,12 @@ local mod = get_mod("NumericUI")
 local UIWidget = require("scripts/managers/ui/ui_widget")
 local UIHudSettings = require("scripts/settings/ui/ui_hud_settings")
 
+local math_min = math.min
+local math_round = math.round
+local table_clone = table.clone
+local table_merge_recursive = table.merge_recursive
+local tostring = tostring
+
 local text_size = 20
 local text_width = 100
 local padding = 10
@@ -18,7 +24,7 @@ local text_style = {
 	-- debug_draw_box = true,
 }
 
-local health_text_style = table.merge_recursive(table.clone(text_style), {
+local health_text_style = table_merge_recursive(table_clone(text_style), {
 	text_color = {
 		255,
 		255,
@@ -30,20 +36,20 @@ local health_text_style = table.merge_recursive(table.clone(text_style), {
 	},
 })
 
-local toughness_text_style = table.merge_recursive(table.clone(text_style), {
+local toughness_text_style = table_merge_recursive(table_clone(text_style), {
 	text_color = UIHudSettings.color_tint_secondary_1,
 	offset = {
 		[2] = -2,
 	},
 })
 
-local left_health_text_style = table.merge_recursive(table.clone(health_text_style), {
+local left_health_text_style = table_merge_recursive(table_clone(health_text_style), {
 	horizontal_alignment = "left",
 	text_horizontal_alignment = "right",
 	offset = { [1] = -(text_width + padding) },
 })
 
-local left_toughness_text_style = table.merge_recursive(table.clone(toughness_text_style), {
+local left_toughness_text_style = table_merge_recursive(table_clone(toughness_text_style), {
 	horizontal_alignment = "left",
 	text_horizontal_alignment = "right",
 	offset = { [1] = -(text_width + padding) },
@@ -115,44 +121,60 @@ local function _get_network_values(game_session, game_object_id)
 	return toughness_damage, max_toughness
 end
 
+local function _set_number(widget, value)
+	local content = widget.content
+
+	if content._numericui_value ~= value then
+		content._numericui_value = value
+		content.text = value and tostring(value) or ""
+		widget.dirty = true
+	end
+end
+
 mod:hook_safe("HudElementBossHealth", "update", function(self)
-	if mod:get("show_boss_health_numbers") then
-		local widget_groups = self._widget_groups
-		local active_targets_array = self._active_targets_array
-		local num_active_targets = math.min(#widget_groups - 1, #active_targets_array)
+	if not mod.setting("show_boss_health_numbers") then
+		return
+	end
 
-		for i = 1, num_active_targets do
-			local widget_group_index = num_active_targets > 1 and i + 1 or i
-			local widget_group = widget_groups[widget_group_index]
-			local target = active_targets_array[i]
-			local unit = target.unit
+	local widget_groups = self._widget_groups
+	local active_targets_array = self._active_targets_array
+	local num_active_targets = math_min(#widget_groups - 1, #active_targets_array)
 
-			widget_group.health_text.content.text = ""
-			widget_group.toughness_text.content.text = ""
+	for i = 1, num_active_targets do
+		local widget_group_index = num_active_targets > 1 and i + 1 or i
+		local widget_group = widget_groups[widget_group_index]
+		local target = active_targets_array[i]
+		local unit = target.unit
 
-			if ALIVE[unit] then
-				local health_extension = target.health_extension
-				local current_health = health_extension:current_health()
+		if ALIVE[unit] then
+			local health_extension = target.health_extension
 
-				widget_group.health_text.content.text = math.round(current_health)
+			_set_number(widget_group.health_text, math_round(health_extension:current_health()))
 
-				local toughness_extension = target.toughness_extension
-				local current_toughness = 0
-				if toughness_extension then
-					if toughness_extension.max_toughness then
-						-- MinionToughnessExtension
-						local max_toughness = toughness_extension:max_toughness()
-						local toughness_damage = toughness_extension:toughness_damage()
-						current_toughness = max_toughness - toughness_damage
-					else
-						-- MinionToughnessHuskExtension
-						local toughness_damage, max_toughness =
-							_get_network_values(toughness_extension._game_session, toughness_extension._game_object_id)
-						current_toughness = max_toughness - toughness_damage
-					end
-					widget_group.toughness_text.content.text = math.round(current_toughness)
+			local toughness_extension = target.toughness_extension
+
+			if toughness_extension then
+				local current_toughness
+
+				if toughness_extension.max_toughness then
+					-- MinionToughnessExtension
+					local max_toughness = toughness_extension:max_toughness()
+					local toughness_damage = toughness_extension:toughness_damage()
+					current_toughness = max_toughness - toughness_damage
+				else
+					-- MinionToughnessHuskExtension
+					local toughness_damage, max_toughness =
+						_get_network_values(toughness_extension._game_session, toughness_extension._game_object_id)
+					current_toughness = max_toughness - toughness_damage
 				end
+
+				_set_number(widget_group.toughness_text, math_round(current_toughness))
+			else
+				_set_number(widget_group.toughness_text, nil)
 			end
+		else
+			_set_number(widget_group.health_text, nil)
+			_set_number(widget_group.toughness_text, nil)
 		end
 	end
 end)

--- a/NumericUI/scripts/mods/NumericUI/HudElementDodgeCount.lua
+++ b/NumericUI/scripts/mods/NumericUI/HudElementDodgeCount.lua
@@ -3,6 +3,19 @@ local mod = get_mod("NumericUI")
 local UIWorkspaceSettings = require("scripts/settings/ui/ui_workspace_settings")
 local UIWidget = require("scripts/managers/ui/ui_widget")
 
+local math_ceil = math.ceil
+local math_clamp = math.clamp
+local math_floor = math.floor
+local math_huge = math.huge
+local math_lerp = math.lerp
+local math_min = math.min
+local math_round = math.round
+local math_round_with_precision = math.round_with_precision
+local string_format = string.format
+local table_clone = table.clone
+local table_merge_recursive = table.merge_recursive
+local tostring = tostring
+
 local size = { 250, 25 }
 local scenegraph_definition = {
 	screen = UIWorkspaceSettings.screen,
@@ -46,18 +59,18 @@ local timer_color = { 0, 0, 0, 0 }
 local timer_size_color = function(time_to_refresh, cooldown, current_dodges, force_show_max_width)
 	-- NB: time_to_refresh will increase towards zero
 	local t_max = cooldown
-	if (-time_to_refresh >= t_max or force_show_max_width) and mod:get("dodge_timer_hide_full") then
+	if (-time_to_refresh >= t_max or force_show_max_width) and mod.setting("dodge_timer_hide_full") then
 		return
 	end
-	local natural_time = force_show_max_width and 0 or math.clamp((time_to_refresh + t_max) / t_max, 0, 1)
+	local natural_time = force_show_max_width and 0 or math_clamp((time_to_refresh + t_max) / t_max, 0, 1)
 
-	timer_size[1] = mod:get("dodge_timer_width") * (1 - natural_time)
-	timer_size[2] = mod:get("dodge_timer_height")
+	timer_size[1] = mod.setting("dodge_timer_width") * (1 - natural_time)
+	timer_size[2] = mod.setting("dodge_timer_height")
 
-	local color_start = _timer_gradient_color(mod:get("color_start"))
-	local color_end = _timer_gradient_color(mod:get("color_end"))
+	local color_start = _timer_gradient_color(mod.setting("color_start"))
+	local color_end = _timer_gradient_color(mod.setting("color_end"))
 	for i = 1, 4 do
-		timer_color[i] = math.lerp(color_start[i], color_end[i], natural_time)
+		timer_color[i] = math_lerp(color_start[i], color_end[i], natural_time)
 	end
 	-- Hide timer if dodges are full (useful when playing with the Agile blessing)
 	if current_dodges == 0 then
@@ -87,7 +100,7 @@ local widget_definitions = {
 			value_id = "text",
 			style_id = "text",
 			pass_type = "text",
-			style = table.merge_recursive(table.clone(style), {
+			style = table_merge_recursive(table_clone(style), {
 				offset = { dodge_count_x_offset, dodge_count_y_offset },
 			}),
 		} },
@@ -110,7 +123,7 @@ local widget_definitions = {
 				},
 			},
 			visibility_function = function(_content, _style)
-				return mod:get("dodge_timer")
+				return mod.setting("dodge_timer")
 			end,
 		},
 	}, "container"),
@@ -120,7 +133,7 @@ local widget_definitions = {
 			value_id = "text",
 			style_id = "text",
 			pass_type = "text",
-			style = table.merge_recursive(table.clone(style), {
+			style = table_merge_recursive(table_clone(style), {
 				offset = { dodge_count_x_offset, dodge_count_y_offset + DEBUG_TEXT_Y_OFFSET },
 				text_vertical_alignment = "top",
 			}),
@@ -136,17 +149,13 @@ HudElementDodgeCount.init = function(self, parent, draw_layer, start_scale)
 		widget_definitions = widget_definitions,
 	})
 
-	local player_manager = Managers.player
-	local player = player_manager:local_player(1)
-	local player_unit = player.player_unit
-	self._player_unit = player_unit
 	self._is_in_hub = mod._is_in_hub()
 end
 
 HudElementDodgeCount._refresh_offsets = function(self)
 	local widgets_by_name = self._widgets_by_name
-	local count_x_offset = mod:get("dodge_count_x_offset") or 0
-	local count_y_offset = mod:get("dodge_count_y_offset") or 0
+	local count_x_offset = mod.setting("dodge_count_x_offset") or 0
+	local count_y_offset = mod.setting("dodge_count_y_offset") or 0
 
 	local count_offset = widgets_by_name.dodge_count.style.text.offset
 	count_offset[1] = count_x_offset
@@ -157,8 +166,46 @@ HudElementDodgeCount._refresh_offsets = function(self)
 	debug_offset[2] = count_y_offset + DEBUG_TEXT_Y_OFFSET
 
 	local timer_offset = widgets_by_name.dodge_timer.style.timer.offset
-	timer_offset[1] = timer_x_offset + (mod:get("dodge_timer_x_offset") or 0)
-	timer_offset[2] = mod:get("dodge_timer_y_offset") or 0
+	timer_offset[1] = timer_x_offset + (mod.setting("dodge_timer_x_offset") or 0)
+	timer_offset[2] = mod.setting("dodge_timer_y_offset") or 0
+end
+
+HudElementDodgeCount._resolve_player = function(self)
+	local player = Managers.player:local_player(1)
+	local player_unit = player and player.player_unit
+
+	if player_unit == self._resolved_unit then
+		return self._unit_data_extension ~= nil
+	end
+
+	self._resolved_unit = player_unit
+	self._unit_data_extension = nil
+	self._weapon_extension = nil
+	self._buff_extension = nil
+
+	if not player_unit or not ALIVE[player_unit] then
+		return false
+	end
+
+	local unit_data_extension = ScriptUnit.has_extension(player_unit, "unit_data_system")
+	local weapon_extension = ScriptUnit.has_extension(player_unit, "weapon_system")
+	local buff_extension = ScriptUnit.has_extension(player_unit, "buff_system")
+
+	if not unit_data_extension or not weapon_extension or not buff_extension then
+		return false
+	end
+
+	self._unit_data_extension = unit_data_extension
+	self._weapon_extension = weapon_extension
+	self._buff_extension = buff_extension
+	self._dodge_state_component = unit_data_extension:read_component("dodge_character_state")
+	self._movement_state_component = unit_data_extension:read_component("movement_state")
+	self._slide_state_component = unit_data_extension:read_component("slide_character_state")
+
+	local archetype = unit_data_extension:archetype()
+	self._base_dodge_template = archetype and archetype.dodge
+
+	return true
 end
 
 local function _calculate_dodge_diminishing_return(
@@ -166,16 +213,14 @@ local function _calculate_dodge_diminishing_return(
 	movement_state_component,
 	slide_state_component,
 	weapon_dodge_template,
-	buff_extension,
+	extra_consecutive_dodges,
 	t
 )
-	local stat_buffs = buff_extension:stat_buffs()
-	local extra_consecutive_dodges = math.round(stat_buffs.extra_consecutive_dodges or 0)
 	local dr_start = (weapon_dodge_template and weapon_dodge_template.diminishing_return_start or 2)
 		+ extra_consecutive_dodges
 	local dr_limit = dr_start + (weapon_dodge_template and weapon_dodge_template.diminishing_return_limit or 1)
 
-	local consecutive_dodges = math.min(dodge_character_state_component.consecutive_dodges, dr_limit + dr_start)
+	local consecutive_dodges = math_min(dodge_character_state_component.consecutive_dodges, dr_limit + dr_start)
 
 	local is_sliding = movement_state_component.method == "sliding"
 	local was_in_dodge_before_slide = slide_state_component.was_in_dodge_cooldown
@@ -193,12 +238,87 @@ local function _calculate_dodge_diminishing_return(
 		or 1
 	local base = 1 - dr_distance_modifier
 	local diminishing_return = base
-		+ dr_distance_modifier * (1 - math.clamp(consecutive_dodges - dr_start, 0, dr_limit) / dr_limit)
+		+ dr_distance_modifier * (1 - math_clamp(consecutive_dodges - dr_start, 0, dr_limit) / dr_limit)
 
 	return consecutive_dodges, dr_start, dr_limit, diminishing_return
 end
 
 local ZERO_SIZE = { 0, 0 }
+
+local function _set_text(widget, text)
+	text = text or ""
+
+	if widget.content.text ~= text then
+		widget.content.text = text
+		widget.dirty = true
+	end
+end
+
+HudElementDodgeCount._clear = function(self)
+	local widgets_by_name = self._widgets_by_name
+
+	_set_text(widgets_by_name.dodge_count, "")
+	_set_text(widgets_by_name.debug_dodge_count, "")
+	widgets_by_name.dodge_timer.style.timer.size = ZERO_SIZE
+
+	self._sample_valid = false
+	self._displayed_count_text = nil
+end
+
+HudElementDodgeCount._sample_changed = function(
+	self,
+	consecutive_dodges,
+	is_cooled_down,
+	is_dodging,
+	method,
+	was_in_dodge_cooldown,
+	weapon_dodge_template,
+	extra_consecutive_dodges
+)
+	if
+		self._sample_valid
+		and consecutive_dodges == self._sampled_dodges
+		and is_cooled_down == self._sampled_cooled_down
+		and is_dodging == self._sampled_is_dodging
+		and method == self._sampled_method
+		and was_in_dodge_cooldown == self._sampled_slide
+		and weapon_dodge_template == self._sampled_template
+		and extra_consecutive_dodges == self._sampled_extra_dodges
+	then
+		return false
+	end
+
+	self._sample_valid = true
+	self._sampled_dodges = consecutive_dodges
+	self._sampled_cooled_down = is_cooled_down
+	self._sampled_is_dodging = is_dodging
+	self._sampled_method = method
+	self._sampled_slide = was_in_dodge_cooldown
+	self._sampled_template = weapon_dodge_template
+	self._sampled_extra_dodges = extra_consecutive_dodges
+
+	return true
+end
+
+HudElementDodgeCount._count_text = function(self, current_dodges, num_efficient_dodges)
+	if num_efficient_dodges == math_huge then
+		if mod.setting("show_dodge_count_for_infinite_dodge") then
+			return tostring(current_dodges)
+		end
+
+		return ""
+	end
+
+	local display_dodges = mod.setting("dodges_count_up") and current_dodges
+		or (math_ceil(num_efficient_dodges) - current_dodges)
+
+	if mod.setting("show_efficient_dodges") then
+		return string_format("%d/%d", display_dodges, math_ceil(num_efficient_dodges))
+	end
+
+	return tostring(math_ceil(display_dodges))
+end
+
 HudElementDodgeCount.update = function(self, dt, t, ui_renderer, render_settings, input_service)
 	HudElementDodgeCount.super.update(self, dt, t, ui_renderer, render_settings, input_service)
 
@@ -207,110 +327,129 @@ HudElementDodgeCount.update = function(self, dt, t, ui_renderer, render_settings
 		self:_refresh_offsets()
 	end
 
-	-- Reset to empty in case we can't fill it in
-	self._widgets_by_name.dodge_count.content.text = ""
-	self._widgets_by_name.debug_dodge_count.content.text = ""
-	self._widgets_by_name.dodge_timer.style.timer.size = ZERO_SIZE
+	local show_dodge_count = mod.setting("dodge_count")
+	local show_dodge_timer = mod.setting("dodge_timer")
+	local show_debug = mod.setting("debug_dodge_count")
 
-	local show_dodge_count = mod:get("dodge_count")
-	local show_dodge_timer = mod:get("dodge_timer")
-	if self._is_in_hub or not (show_dodge_count or show_dodge_timer) then
+	if self._is_in_hub or not (show_dodge_count or show_dodge_timer or show_debug) then
+		self:_clear()
 		return
 	end
 
-	-- copy into the widget's own color table in place instead of cloning a new one every frame
-	local style = self._widgets_by_name.dodge_count.style
-	_copy_color(style.text.text_color, color_efficient)
+	if not self:_resolve_player() then
+		self:_clear()
+		return
+	end
 
-	local unit_data_extension = ScriptUnit.extension(self._player_unit, "unit_data_system")
-	local weapon_extension = ScriptUnit.has_extension(self._player_unit, "weapon_system")
-	local buff_extension = ScriptUnit.extension(self._player_unit, "buff_system")
-	if unit_data_extension and weapon_extension and buff_extension then
-		local dodge_state_component = unit_data_extension:read_component("dodge_character_state")
-		local movement_state_component = unit_data_extension:read_component("movement_state")
-		local slide_state_component = unit_data_extension:read_component("slide_character_state")
-		local weapon_dodge_template = weapon_extension:dodge_template()
-		local gameplay_t = Managers.time:time("gameplay")
-		local cooldown = dodge_state_component.consecutive_dodges_cooldown - gameplay_t
+	local widgets_by_name = self._widgets_by_name
+	local dodge_state_component = self._dodge_state_component
+	local movement_state_component = self._movement_state_component
+	local slide_state_component = self._slide_state_component
+	local weapon_dodge_template = self._weapon_extension:dodge_template()
+	local stat_buffs = self._buff_extension:stat_buffs()
+	local extra_consecutive_dodges = math_round(stat_buffs.extra_consecutive_dodges or 0)
+	local gameplay_t = Managers.time:time("gameplay")
+	local consecutive_dodges_cooldown = dodge_state_component.consecutive_dodges_cooldown
 
-		local current_dodges, num_efficient_dodges, dr_limit, distance_modifier = _calculate_dodge_diminishing_return(
-			dodge_state_component,
-			movement_state_component,
-			slide_state_component,
-			weapon_dodge_template,
-			buff_extension,
-			gameplay_t
-		)
+	local changed = self:_sample_changed(
+		dodge_state_component.consecutive_dodges,
+		consecutive_dodges_cooldown < gameplay_t,
+		movement_state_component.is_dodging,
+		movement_state_component.method,
+		slide_state_component.was_in_dodge_cooldown,
+		weapon_dodge_template,
+		extra_consecutive_dodges
+	)
 
-		if show_dodge_timer then
-			local archetype = unit_data_extension:archetype()
-			local base_dodge_template = archetype.dodge
-			local weapon_consecutive_dodges_reset = weapon_dodge_template
-					and weapon_dodge_template.consecutive_dodges_reset
-				or 0
-			local stat_buffs = buff_extension:stat_buffs()
-			local buff_modifier = stat_buffs.dodge_cooldown_reset_modifier
-			local buff_dodge_cooldown_reset_modifier = buff_modifier and 1 - (buff_modifier - 1) or 1
-			local relative_cooldown = (base_dodge_template.consecutive_dodges_reset + weapon_consecutive_dodges_reset)
-				* buff_dodge_cooldown_reset_modifier
+	if changed then
+		local current_dodges, num_efficient_dodges, dr_limit, distance_modifier =
+			_calculate_dodge_diminishing_return(
+				dodge_state_component,
+				movement_state_component,
+				slide_state_component,
+				weapon_dodge_template,
+				extra_consecutive_dodges,
+				gameplay_t
+			)
 
-			local is_actually_dodging = (movement_state_component.method ~= "vaulting")
-				and movement_state_component.is_dodging
-			local relative_time = gameplay_t - dodge_state_component.consecutive_dodges_cooldown
-			local force_show_max_width = current_dodges ~= 0
-				and (is_actually_dodging or movement_state_component.method == "sliding")
-			local timer_size, timer_color =
-				timer_size_color(relative_time, relative_cooldown, current_dodges, force_show_max_width)
+		self._current_dodges = current_dodges
+		self._num_efficient_dodges = num_efficient_dodges
+		self._dr_limit = dr_limit
+		self._distance_modifier = distance_modifier
+		self._displayed_count_text = show_dodge_count and self:_count_text(current_dodges, num_efficient_dodges)
+			or ""
+	end
 
-			self._widgets_by_name.dodge_timer.style.timer.size = timer_size or ZERO_SIZE
-			self._widgets_by_name.dodge_timer.style.timer.color = timer_color or color_timer_hidden
+	local current_dodges = self._current_dodges
+	local num_efficient_dodges = self._num_efficient_dodges
+	local dr_limit = self._dr_limit
+
+	local base_dodge_template = self._base_dodge_template
+
+	if show_dodge_timer and base_dodge_template then
+		local weapon_consecutive_dodges_reset = weapon_dodge_template
+				and weapon_dodge_template.consecutive_dodges_reset
+			or 0
+		local buff_modifier = stat_buffs.dodge_cooldown_reset_modifier
+		local buff_dodge_cooldown_reset_modifier = buff_modifier and 1 - (buff_modifier - 1) or 1
+		local relative_cooldown = (base_dodge_template.consecutive_dodges_reset + weapon_consecutive_dodges_reset)
+			* buff_dodge_cooldown_reset_modifier
+
+		local is_actually_dodging = (movement_state_component.method ~= "vaulting")
+			and movement_state_component.is_dodging
+		local relative_time = gameplay_t - consecutive_dodges_cooldown
+		local force_show_max_width = current_dodges ~= 0
+			and (is_actually_dodging or movement_state_component.method == "sliding")
+		local size, color = timer_size_color(relative_time, relative_cooldown, current_dodges, force_show_max_width)
+
+		widgets_by_name.dodge_timer.style.timer.size = size or ZERO_SIZE
+		widgets_by_name.dodge_timer.style.timer.color = color or color_timer_hidden
+	else
+		widgets_by_name.dodge_timer.style.timer.size = ZERO_SIZE
+	end
+
+	if show_dodge_count then
+		local text_color = widgets_by_name.dodge_count.style.text.text_color
+		_copy_color(text_color, color_efficient)
+
+		_set_text(widgets_by_name.dodge_count, self._displayed_count_text)
+
+		if current_dodges >= num_efficient_dodges then
+			_copy_color(text_color, color_inefficient)
 		end
 
-		if show_dodge_count then
-			if num_efficient_dodges == math.huge then
-				if mod:get("show_dodge_count_for_infinite_dodge") then
-					self._widgets_by_name.dodge_count.content.text = tostring(current_dodges)
-				end
-			else
-				local display_dodges = mod:get("dodges_count_up") and current_dodges
-					or (math.ceil(num_efficient_dodges) - current_dodges)
-
-				if mod:get("show_efficient_dodges") then
-					self._widgets_by_name.dodge_count.content.text =
-						string.format("%d/%d", display_dodges, math.ceil(num_efficient_dodges))
-				else
-					self._widgets_by_name.dodge_count.content.text = tostring(math.ceil(display_dodges))
-				end
-			end
-
-			if current_dodges >= num_efficient_dodges then
-				_copy_color(style.text.text_color, color_inefficient)
-			end
-
-			if current_dodges >= math.floor(dr_limit + num_efficient_dodges) then
-				_copy_color(style.text.text_color, color_limit)
-			end
-
-			if mod:get("fade_out_max_dodges") and current_dodges == 0 then
-				local time_since_cooldown =
-					math.clamp(gameplay_t - dodge_state_component.consecutive_dodges_cooldown - 1, 0, 1)
-				style.text.text_color[1] = math.lerp(255, 0, time_since_cooldown)
-			end
+		if current_dodges >= math_floor(dr_limit + num_efficient_dodges) then
+			_copy_color(text_color, color_limit)
 		end
 
-		if mod:get("debug_dodge_count") then
-			self._widgets_by_name.debug_dodge_count.content.text = string.format(
+		if mod.setting("fade_out_max_dodges") and current_dodges == 0 then
+			local time_since_cooldown = math_clamp(gameplay_t - consecutive_dodges_cooldown - 1, 0, 1)
+			text_color[1] = math_lerp(255, 0, time_since_cooldown)
+		end
+	else
+		_set_text(widgets_by_name.dodge_count, "")
+	end
+
+	if show_debug then
+		local cooldown = consecutive_dodges_cooldown - gameplay_t
+
+		_set_text(
+			widgets_by_name.debug_dodge_count,
+			string_format(
 				"%d/%s/%s\nmodifier: x%.2f\ncooldown: %.2fs\ndodging: %s\nsliding: %s",
 				current_dodges,
-				num_efficient_dodges == math.huge and "inf"
-					or tostring(math.round_with_precision(num_efficient_dodges, 2)),
-				num_efficient_dodges == math.huge and "inf" or tostring(math.floor(dr_limit + num_efficient_dodges)),
-				distance_modifier,
+				num_efficient_dodges == math_huge and "inf"
+					or tostring(math_round_with_precision(num_efficient_dodges, 2)),
+				num_efficient_dodges == math_huge and "inf"
+					or tostring(math_floor(dr_limit + num_efficient_dodges)),
+				self._distance_modifier,
 				cooldown > 0 and cooldown or 0,
 				tostring(movement_state_component.is_dodging),
 				tostring(movement_state_component.method == "sliding")
 			)
-		end
+		)
+	else
+		_set_text(widgets_by_name.debug_dodge_count, "")
 	end
 end
 

--- a/NumericUI/scripts/mods/NumericUI/HudElementMissionTimer.lua
+++ b/NumericUI/scripts/mods/NumericUI/HudElementMissionTimer.lua
@@ -3,6 +3,10 @@ local mod = get_mod("NumericUI")
 local UIWorkspaceSettings = require("scripts/settings/ui/ui_workspace_settings")
 local UIWidget = require("scripts/managers/ui/ui_widget")
 
+local math_floor = math.floor
+local math_fmod = math.fmod
+local string_format = string.format
+
 local font_size = 24
 local size = { 60, font_size }
 local scenegraph_definition = {
@@ -51,16 +55,18 @@ HudElementMissionTimer.init = function(self, parent, draw_layer, start_scale)
 end
 
 HudElementMissionTimer._disp_time = function(time)
-	local minutes = math.floor(math.fmod(time, 3600) / 60)
-	local seconds = math.floor(math.fmod(time, 60))
-	return string.format("%02d:%02d", minutes, seconds)
+	local minutes = math_floor(math_fmod(time, 3600) / 60)
+	local seconds = math_floor(math_fmod(time, 60))
+	return string_format("%02d:%02d", minutes, seconds)
 end
 
 HudElementMissionTimer.update = function(self, dt, t, ui_renderer, render_settings, input_service)
 	HudElementMissionTimer.super.update(self, dt, t, ui_renderer, render_settings, input_service)
-	local enabled = mod:get("show_mission_timer")
-	local active = not mod:get("mission_timer_in_overlay")
-	local content = self._widgets_by_name.timer.content
+
+	local widget = self._widgets_by_name.timer
+	local enabled = mod.setting("show_mission_timer")
+	local active = not mod.setting("mission_timer_in_overlay")
+
 	local gameplay_input_service = Managers.input:get_input_service("Ingame")
 
 	if gameplay_input_service:get("tactical_overlay_hold") then
@@ -68,9 +74,17 @@ HudElementMissionTimer.update = function(self, dt, t, ui_renderer, render_settin
 	end
 
 	if enabled and active and not self._is_in_hub then
-		content.text = self._disp_time(Managers.time:time("gameplay"))
-	else
-		content.text = ""
+		local second = math_floor(Managers.time:time("gameplay"))
+
+		if second ~= self._displayed_second then
+			self._displayed_second = second
+			widget.content.text = self._disp_time(second)
+			widget.dirty = true
+		end
+	elseif widget.content.text ~= "" then
+		self._displayed_second = nil
+		widget.content.text = ""
+		widget.dirty = true
 	end
 end
 

--- a/NumericUI/scripts/mods/NumericUI/Interactions.lua
+++ b/NumericUI/scripts/mods/NumericUI/Interactions.lua
@@ -4,105 +4,170 @@
 local mod = get_mod("NumericUI")
 
 local Pickups = require("scripts/settings/pickup/pickups")
-local Havoc = require("scripts/utilities/havoc")
-local HavocSettings = require("scripts/settings/havoc_settings")
 local Ammo = require("scripts/utilities/ammo")
+
+local string_format = string.format
+local pairs = pairs
 
 local small_clip_data = Pickups.by_name["small_clip"]
 local large_clip_data = Pickups.by_name["large_clip"]
 
-mod:hook_safe("HudElementInteraction", "update", function(self)
-	if mod:get("show_ammo_amount_from_packs") then
-		if self._active_presentation_data then
-			local interactor_extension = self._active_presentation_data.interactor_extension
-			local description_widget = self._widgets_by_name.description_text
+local SMALL_CLIP_DESCRIPTION = "loc_pickup_consumable_small_clip_01"
+local LARGE_CLIP_DESCRIPTION = "loc_pickup_consumable_large_clip_01"
 
-			local hud_description = interactor_extension:hud_description()
+local function _havoc_ammo_modifier()
+	local cached = mod._havoc_ammo_modifier
 
-			if hud_description == nil then
-				return
-			end
+	if cached then
+		return cached
+	end
 
-			local player = Managers.player:local_player(1)
-			local player_unit = player.player_unit
-			local unit_data_ext = ScriptUnit.extension(player_unit, "unit_data_system")
-			local visual_loadout_extension = ScriptUnit.extension(player_unit, "visual_loadout_system")
-			local weapon_slot_configuration = visual_loadout_extension:slot_configuration_by_type("weapon")
-			local ammo_modifier = 1
-			if Managers.mechanism._mechanism then
-				local mechanism_data = Managers.mechanism._mechanism._mechanism_data
-				if mechanism_data.havoc_data then
-					local parsed = Havoc.parse_data(mechanism_data.havoc_data)
-					if parsed.modifiers then
-						for _, modifier in ipairs(parsed.modifiers) do
-							if modifier.name == "ammo_pickup_modifier" then
-								ammo_modifier = HavocSettings.modifier_templates.ammo_pickup_modifier[modifier.level].ammo_pickup_modifier
-									or 1
-							end
-						end
-					end
-				end
-			end
+	local modifier = 1
+	local game_mode_manager = Managers.state.game_mode
+	local game_mode = game_mode_manager and game_mode_manager:game_mode()
+	local havoc_extension = game_mode and game_mode.extension and game_mode:extension("havoc")
 
-			local max_ammo_reserve = 0
-			local ammo_reserve = 0
-			local ammo_clip = 0
-			local max_ammo_clip = 0
+	if havoc_extension then
+		modifier = havoc_extension:get_modifier_value("ammo_pickup_modifier") or 1
+	end
 
-			for slot_name in pairs(weapon_slot_configuration) do
-				local wieldable_component = unit_data_ext:write_component(slot_name)
-				if wieldable_component.max_ammunition_reserve > 0 then
-					ammo_reserve = Ammo.current_ammo_in_reserve(wieldable_component)
-					max_ammo_reserve = Ammo.max_ammo_in_reserve(wieldable_component)
-					ammo_clip = Ammo.current_ammo_in_clips(wieldable_component)
-					max_ammo_clip = Ammo.max_ammo_in_clips(wieldable_component)
-					break
-				end
-			end
+	mod._havoc_ammo_modifier = modifier
 
-			local max_ammo = max_ammo_reserve + max_ammo_clip
-			local current_ammo = ammo_clip + ammo_reserve
+	return modifier
+end
 
-			small_clip_data.modifier = ammo_modifier
-			large_clip_data.modifier = ammo_modifier
+local function _weapon_ammo_totals(player_unit)
+	local unit_data_extension = ScriptUnit.has_extension(player_unit, "unit_data_system")
+	local visual_loadout_extension = ScriptUnit.has_extension(player_unit, "visual_loadout_system")
 
-			local small_clip_gain = small_clip_data.ammo_amount_func(max_ammo_reserve, max_ammo_clip, small_clip_data)
-			local large_clip_gain = large_clip_data.ammo_amount_func(max_ammo_reserve, max_ammo_clip, large_clip_data)
+	if not unit_data_extension or not visual_loadout_extension then
+		return
+	end
 
-			if description_widget and max_ammo then
-				local missing_ammo = max_ammo - current_ammo
-				local ammo_gain = 0
-				local ammo_wasted = 0
+	local weapon_slot_configuration = visual_loadout_extension:slot_configuration_by_type("weapon")
 
-				if hud_description == "loc_pickup_consumable_small_clip_01" then
-					if missing_ammo >= small_clip_gain then
-						ammo_gain = small_clip_gain
-					elseif missing_ammo > 0 then
-						ammo_gain = missing_ammo
-						ammo_wasted = small_clip_gain - missing_ammo
-					end
-				elseif hud_description == "loc_pickup_consumable_large_clip_01" then
-					if missing_ammo >= large_clip_gain then
-						ammo_gain = large_clip_gain
-					elseif missing_ammo > 0 then
-						ammo_gain = missing_ammo
-						ammo_wasted = large_clip_gain - missing_ammo
-					end
-				end
+	for slot_name in pairs(weapon_slot_configuration) do
+		local wieldable_component = unit_data_extension:read_component(slot_name)
 
-				local show_ammo_gain = ammo_gain > 0
-				local show_ammo_wasted = ammo_wasted > 0
-
-				local desc_str = show_ammo_gain
-						and show_ammo_wasted
-						and "%s {#color(0,255,0,200);}(+%d) {#color(255,0,0,200);}(%d)"
-					or show_ammo_gain and not show_ammo_wasted and "%s {#color(0,255,0,200);}(+%d)"
-					or "%s"
-
-				description_widget.content.text =
-					string.format(desc_str, Localize(hud_description), ammo_gain, ammo_wasted)
-				description_widget.dirty = true
-			end
+		if wieldable_component and wieldable_component.max_ammunition_reserve > 0 then
+			return Ammo.current_ammo_in_reserve(wieldable_component),
+				Ammo.max_ammo_in_reserve(wieldable_component),
+				Ammo.current_ammo_in_clips(wieldable_component),
+				Ammo.max_ammo_in_clips(wieldable_component)
 		end
 	end
+end
+
+local function _pickup_gain(pickup_data, max_ammo_reserve, max_ammo_clip, ammo_modifier)
+	local previous_modifier = pickup_data.modifier
+
+	pickup_data.modifier = ammo_modifier
+
+	local gain = pickup_data.ammo_amount_func(max_ammo_reserve, max_ammo_clip, pickup_data)
+
+	pickup_data.modifier = previous_modifier
+
+	return gain
+end
+
+local function _update_pickup_description(self, interactor_extension)
+	local description_widget = self._widgets_by_name.description_text
+	local base_text = self._numericui_pickup_base_text
+	local hud_description = self._numericui_pickup_hud_description
+
+	if not description_widget or not base_text then
+		return
+	end
+
+	if hud_description ~= SMALL_CLIP_DESCRIPTION and hud_description ~= LARGE_CLIP_DESCRIPTION then
+		return
+	end
+
+	local player = Managers.player:local_player(1)
+	local player_unit = player and player.player_unit
+
+	if not player_unit then
+		return
+	end
+
+	local ammo_reserve, max_ammo_reserve, ammo_clip, max_ammo_clip = _weapon_ammo_totals(player_unit)
+
+	if not ammo_reserve then
+		return
+	end
+
+	local ammo_modifier = _havoc_ammo_modifier()
+	local pickup_data = hud_description == SMALL_CLIP_DESCRIPTION and small_clip_data or large_clip_data
+	local clip_gain = _pickup_gain(pickup_data, max_ammo_reserve, max_ammo_clip, ammo_modifier)
+
+	local max_ammo = max_ammo_reserve + max_ammo_clip
+	local current_ammo = ammo_clip + ammo_reserve
+	local missing_ammo = max_ammo - current_ammo
+	local ammo_gain = 0
+	local ammo_wasted = 0
+
+	if missing_ammo >= clip_gain then
+		ammo_gain = clip_gain
+	elseif missing_ammo > 0 then
+		ammo_gain = missing_ammo
+		ammo_wasted = clip_gain - missing_ammo
+	end
+
+	local show_ammo_gain = ammo_gain > 0
+	local show_ammo_wasted = ammo_wasted > 0
+
+	local desc_str = show_ammo_gain
+			and show_ammo_wasted
+			and "%s {#color(0,255,0,200);}(+%d) {#color(255,0,0,200);}(%d)"
+		or show_ammo_gain and not show_ammo_wasted and "%s {#color(0,255,0,200);}(+%d)"
+		or "%s"
+
+	local text = string_format(desc_str, base_text, ammo_gain, ammo_wasted)
+
+	if description_widget.content.text ~= text then
+		description_widget.content.text = text
+		description_widget.dirty = true
+	end
+end
+
+mod:hook_safe(
+	"HudElementInteraction",
+	"_setup_interaction_information",
+	function(self, _interactee_unit, _interactee_extension, interactor_extension, use_minimal_presentation)
+	self._numericui_pickup_base_text = nil
+	self._numericui_pickup_hud_description = nil
+
+	if use_minimal_presentation or not mod.setting("show_ammo_amount_from_packs") then
+		return
+	end
+
+	local hud_description = interactor_extension:hud_description()
+
+	if hud_description ~= SMALL_CLIP_DESCRIPTION and hud_description ~= LARGE_CLIP_DESCRIPTION then
+		return
+	end
+
+	local description_widget = self._widgets_by_name.description_text
+
+	self._numericui_pickup_hud_description = hud_description
+	self._numericui_pickup_base_text = description_widget and description_widget.content.text
+
+	_update_pickup_description(self, interactor_extension)
+	mod._pickup_preview_dirty = false
+end)
+
+mod:hook_safe("HudElementInteraction", "update", function(self)
+	if not mod._pickup_preview_dirty then
+		return
+	end
+
+	mod._pickup_preview_dirty = false
+
+	local active_presentation_data = self._active_presentation_data
+
+	if not active_presentation_data then
+		return
+	end
+
+	_update_pickup_description(self, active_presentation_data.interactor_extension)
 end)

--- a/NumericUI/scripts/mods/NumericUI/NumericUI.lua
+++ b/NumericUI/scripts/mods/NumericUI/NumericUI.lua
@@ -3,6 +3,10 @@
 -- Author: raindish
 local mod = get_mod("NumericUI")
 
+local table_find_by_key = table.find_by_key
+local table_insert = table.insert
+local ipairs = ipairs
+
 mod:io_dofile("NumericUI/scripts/mods/NumericUI/utils")
 mod:io_dofile("NumericUI/scripts/mods/NumericUI/TeamPlayerPanel")
 mod:io_dofile("NumericUI/scripts/mods/NumericUI/PlayerAbility")
@@ -41,8 +45,8 @@ end
 
 mod:hook("UIHud", "init", function(func, self, elements, visibility_groups, params)
 	for _, hud_element in ipairs(hud_elements) do
-		if not table.find_by_key(elements, "class_name", hud_element.class_name) then
-			table.insert(elements, {
+		if not table_find_by_key(elements, "class_name", hud_element.class_name) then
+			table_insert(elements, {
 				class_name = hud_element.class_name,
 				filename = hud_element.filename,
 				use_hud_scale = true,
@@ -107,6 +111,8 @@ mod.update = function(dt)
 end
 
 mod.on_all_mods_loaded = function()
+	mod.flush_settings()
+
 	initialized = false
 	recreate_hud_delay = 0
 	if mod:get("show_medical_crate_radius") then
@@ -116,6 +122,8 @@ mod.on_all_mods_loaded = function()
 end
 
 mod.on_setting_changed = function(setting_id)
+	mod.flush_settings()
+
 	if live_applied_settings[setting_id] then
 		mod._dodge_hud_dirty = true
 		return
@@ -123,4 +131,12 @@ mod.on_setting_changed = function(setting_id)
 
 	initialized = false
 	recreate_hud_delay = RECREATE_HUD_DELAY
+end
+
+mod.on_game_state_changed = function(status, state)
+	if state == "GameplayStateRun" then
+		-- Mission-scoped caches (Havoc modifiers, ammo pickup preview) must not survive a mission.
+		mod._havoc_ammo_modifier = nil
+		mod._pickup_preview_dirty = false
+	end
 end

--- a/NumericUI/scripts/mods/NumericUI/PlayerAbility.lua
+++ b/NumericUI/scripts/mods/NumericUI/PlayerAbility.lua
@@ -4,7 +4,12 @@ local HudElementPlayerAbilitySettings =
 local UIWidget = require("scripts/managers/ui/ui_widget")
 local UIFontSettings = require("scripts/managers/ui/ui_font_settings")
 
-local style = table.clone(UIFontSettings.hud_body)
+local math_floor = math.floor
+local math_huge = math.huge
+local string_format = string.format
+local table_clone = table.clone
+
+local style = table_clone(UIFontSettings.hud_body)
 style.text_horizontal_alignment = "center"
 style.text_vertical_alignment = "center"
 
@@ -37,63 +42,93 @@ mod:hook(_G, "dofile", function(func, path)
 	return instance
 end)
 
-mod:hook_safe("HudElementPlayerAbility", "update", function(self)
-	local widgets_by_name = self._widgets_by_name
-	local ability_widget = widgets_by_name.ability
-	local text_widget = widgets_by_name.cooldown_timer
-	local ability_cooldown_format = mod:get("ability_cooldown_format")
+local function _remaining_cooldown(self)
+	local parent = self._parent
+	local player = self._data and self._data.player
 
+	if not parent or not player then
+		return
+	end
+
+	local ability_extension = parent:get_player_extension(player, "ability_system")
+
+	if not ability_extension then
+		return
+	end
+
+	local remaining = ability_extension:remaining_ability_cooldown(self._ability_id)
+
+	if not remaining or remaining == math_huge then
+		return
+	end
+
+	return remaining
+end
+
+local function _update_cooldown_text(self)
+	local text_widget = self._widgets_by_name.cooldown_timer
+
+	if not text_widget then
+		return
+	end
+
+	local content = text_widget.content
 	local progress = self._ability_progress
 	local on_cooldown = self._on_cooldown
+	-- new_text stays nil while the displayed value is unchanged, so the
+	-- retained widget is only re-rendered when the text actually changes
+	local new_text
 
-	if text_widget then
-		local content = text_widget.content
-		-- new_text stays nil while the displayed value is unchanged, so the
-		-- retained widget is only re-rendered when the text actually changes
-		local new_text
+	if not on_cooldown or not progress or progress >= 1 then
+		content._numericui_last_value = nil
+		new_text = " "
+	else
+		local ability_cooldown_format = mod.setting("ability_cooldown_format")
 
-		if not on_cooldown or progress >= 1 then
-			content._numericui_last_value = nil
-			new_text = " "
-		else
-			if ability_cooldown_format == "percent" then
-				local percent = math.floor(progress * 100)
-				if content._numericui_last_value ~= percent then
-					content._numericui_last_value = percent
-					new_text = string.format("%d%%", percent)
-				end
-			elseif ability_cooldown_format == "time" then
-				local player = self._data.player
-				local player_unit = player.player_unit
-				local unit_data_extension = ScriptUnit.extension(player_unit, "unit_data_system")
-				local ability_state_component = unit_data_extension:read_component("combat_ability")
-				local time = Managers.time:time("gameplay")
-				local time_remaining = math.max(ability_state_component.cooldown - time, 0)
-				if time_remaining <= 1 then
-					content._numericui_last_value = nil
-					new_text = string.format("%.1f", time_remaining)
-				else
-					local seconds = math.floor(time_remaining)
-					if content._numericui_last_value ~= seconds then
-						content._numericui_last_value = seconds
-						new_text = string.format("%d", seconds)
-					end
-				end
-			else
+		if ability_cooldown_format == "percent" then
+			local percent = math_floor(progress * 100)
+			if content._numericui_last_value ~= percent then
+				content._numericui_last_value = percent
+				new_text = string_format("%d%%", percent)
+			end
+		elseif ability_cooldown_format == "time" then
+			local time_remaining = _remaining_cooldown(self)
+
+			if not time_remaining then
 				content._numericui_last_value = nil
 				new_text = " "
+			elseif time_remaining <= 1 then
+				content._numericui_last_value = nil
+				new_text = string_format("%.1f", time_remaining)
+			else
+				local seconds = math_floor(time_remaining)
+				if content._numericui_last_value ~= seconds then
+					content._numericui_last_value = seconds
+					new_text = string_format("%d", seconds)
+				end
 			end
-		end
-
-		if new_text and content.text ~= new_text then
-			content.text = new_text
-			text_widget.dirty = true
+		else
+			content._numericui_last_value = nil
+			new_text = " "
 		end
 	end
 
-	if mod:get("disable_ability_background_progress") then
-		if progress < 1.0 then
-			ability_widget.content.duration_progress = 0.0
-		end
+	if new_text and content.text ~= new_text then
+		content.text = new_text
+		text_widget.dirty = true
 	end
+end
+
+mod:hook_safe("HudElementPlayerAbility", "_set_progress", function(self)
+	local progress = self._ability_progress
+
+	if mod.setting("disable_ability_background_progress") and progress < 1.0 then
+		self._widgets_by_name.ability.content.duration_progress = 0.0
+	end
+
+	_update_cooldown_text(self)
+end)
+
+mod:hook_safe("HudElementPlayerAbility", "_set_widget_state_colors", function(self)
+	_update_cooldown_text(self)
 end)

--- a/NumericUI/scripts/mods/NumericUI/PlayerWeapon.lua
+++ b/NumericUI/scripts/mods/NumericUI/PlayerWeapon.lua
@@ -3,7 +3,6 @@
 -- Author: groundskeeper Willie, raindish
 
 local mod = get_mod("NumericUI")
-local Ammo = require("scripts/utilities/ammo")
 local PLAYER_WEAPON_HUD_DEF_PATH = "scripts/ui/hud/elements/player_weapon/hud_element_player_weapon_definitions"
 
 local backups = mod:persistent_table("player_weapon_hud_backups")
@@ -14,15 +13,18 @@ local UIHudSettings = require("scripts/settings/ui/ui_hud_settings")
 local HudElementTeamPlayerPanelSettings =
 	require("scripts/ui/hud/elements/team_player_panel/hud_element_team_player_panel_settings")
 
---Init global vars for mod: "show_munitions_gained"
-local prev_clip_ammo_char_len = 0 -- Tells where ammo icon should be generated
-local prev_font_size = nil -- checks to see if the font was changed in some way
-local prev_grenade_charges = 0 --Keeps track of grenade amount in the previous loop.
-local grenade_gained_display_t = 0 --keeps track of how long the grenade gained widget has been displayed
-local grenade_gained_amount = 0 --Keeps track of the amount of grenades gained
+local math_abs = math.abs
+local math_floor = math.floor
+local math_min = math.min
+local string_format = string.format
+local table_clone = table.clone
+local table_insert = table.insert
+local table_merge_recursive = table.merge_recursive
+local table_remove = table.remove
+
+local AMMO_ICON_MATERIAL = "content/ui/materials/hud/icons/party_ammo"
+
 local ammo_gained_cumulative = false --When true, will use a single widget to show multiple ammo increments
-local ammo_gained_available_widgets = {} --List of non-active ammo-gained widgets (for non-cumulative display)
-local ammo_gained_active_widgets = {}
 local ammo_gained_data = {
 	widget_name = "ammo_gained_1",
 	amount = 0,
@@ -33,8 +35,10 @@ local ammo_gained_data = {
 	alpha_multiplier = 1,
 }
 
--- reusable scratch storage for Ammo.clips_in_use (fully overwritten on every call)
-local _clips_in_use_scratch = {}
+-- Templates for the ammo-gained widget pool. Every HudElementPlayerWeapon gets its own copy,
+-- because there is one element per weapon slot and each owns its own ammo_gained_* widgets.
+local ammo_gained_widget_templates = {}
+
 -- "ammo_text_" .. i built once instead of every frame
 local _ammo_text_widget_names = {}
 
@@ -49,19 +53,19 @@ local directional_magnitude = 200
 for i = 1, 4 do
 	directional_magnitude = directional_magnitude * -1
 
-	table.insert(ammo_gained_available_widgets, table.clone(ammo_gained_data))
-	ammo_gained_available_widgets[i].widget_name = "ammo_gained_" .. i
-	ammo_gained_available_widgets[i].offset_mod[1] = ammo_gained_data.offset_mod[1] + 5 * (i / directional_magnitude)
-	ammo_gained_available_widgets[i].offset_mod[2] =
-		math.abs(ammo_gained_data.offset_mod[2] + (i / directional_magnitude))
-	ammo_gained_available_widgets[i].offset_slow_mod[1] = ammo_gained_data.offset_slow_mod[1]
+	table_insert(ammo_gained_widget_templates, table_clone(ammo_gained_data))
+	ammo_gained_widget_templates[i].widget_name = "ammo_gained_" .. i
+	ammo_gained_widget_templates[i].offset_mod[1] = ammo_gained_data.offset_mod[1] + 5 * (i / directional_magnitude)
+	ammo_gained_widget_templates[i].offset_mod[2] =
+		math_abs(ammo_gained_data.offset_mod[2] + (i / directional_magnitude))
+	ammo_gained_widget_templates[i].offset_slow_mod[1] = ammo_gained_data.offset_slow_mod[1]
 		+ 5 * (i / directional_magnitude)
-	ammo_gained_available_widgets[i].offset_slow_mod[2] =
-		math.abs(ammo_gained_data.offset_slow_mod[2] + (i / directional_magnitude))
+	ammo_gained_widget_templates[i].offset_slow_mod[2] =
+		math_abs(ammo_gained_data.offset_slow_mod[2] + (i / directional_magnitude))
 end
 
 mod:hook_require(PLAYER_WEAPON_HUD_DEF_PATH, function(instance)
-	backups.definitions = backups.definitions or table.clone(instance)
+	backups.definitions = backups.definitions or table_clone(instance)
 
 	instance.widget_definitions.ammo_icon = UIWidget.create_definition({
 		{
@@ -181,19 +185,21 @@ mod:hook_require(PLAYER_WEAPON_HUD_DEF_PATH, function(instance)
 		},
 	}, "weapon")
 
-	local spare_ammo_style = table.clone(backups.definitions.widget_definitions.ammo_text_1.style.ammo_spare_1)
+	local spare_ammo_style = table_clone(backups.definitions.widget_definitions.ammo_text_1.style.ammo_spare_1)
 	local modifier = 0.8
 
 	for i = 1, NetworkConstants.clips_in_use.max_size do
+		_ammo_text_widget_names[i] = "ammo_text_" .. i
+
 		local ammo_text_widget_orig = backups.definitions.widget_definitions["ammo_text_" .. i]
 		if ammo_text_widget_orig then
-			local ammo_text_widget = table.clone(ammo_text_widget_orig)
+			local ammo_text_widget = table_clone(ammo_text_widget_orig)
 			UIWidget.add_definition_pass(ammo_text_widget, {
 				value_id = "max_ammo",
 				style_id = "max_ammo",
 				pass_type = "text",
 				value = "",
-				style = table.merge_recursive(spare_ammo_style, {
+				style = table_merge_recursive(spare_ammo_style, {
 					font_size = spare_ammo_style.font_size * modifier,
 					default_font_size = spare_ammo_style.default_font_size * modifier,
 					focused_font_size = spare_ammo_style.focused_font_size * modifier,
@@ -204,27 +210,27 @@ mod:hook_require(PLAYER_WEAPON_HUD_DEF_PATH, function(instance)
 	end
 end)
 
-local function display_grenade_gained(dt, widget)
-	if grenade_gained_amount == 0 then
+local function display_grenade_gained(dt, widget, data)
+	if data.amount == 0 then
 		return false
 	end
 
-	local display_t = grenade_gained_display_t
+	local display_t = data.display_t
 	local widget_cleared = false
 
 	if display_t < 1.5 then
 		widget.style.grenade_gained.offset[2] = widget.style.grenade_gained.offset[2] - (0.1 / display_t)
 		widget.style.grenade_gained.offset[1] = widget.style.grenade_gained.offset[1] - (0.2 / display_t)
-		grenade_gained_display_t = display_t + dt
+		data.display_t = display_t + dt
 	elseif display_t < 2.5 then
 		widget.style.grenade_gained.offset[2] = widget.style.grenade_gained.offset[2] - (0.1 / display_t)
 		widget.style.grenade_gained.offset[1] = widget.style.grenade_gained.offset[1] - (0.15 / display_t)
 		widget.alpha_multiplier = 2.5 - display_t
-		grenade_gained_display_t = display_t + dt
+		data.display_t = display_t + dt
 	else
 		widget.style.grenade_gained.offset = { 120, -110, 10 }
-		grenade_gained_display_t = 0
-		grenade_gained_amount = 0
+		data.display_t = 0
+		data.amount = 0
 		widget.alpha_multiplier = 1
 		widget.content.grenade_gained = " "
 		widget_cleared = true
@@ -271,7 +277,7 @@ local function display_ammo_gained(dt, widget, data)
 		data.alpha_multiplier = 2.5 - display_t
 		data.display_t = display_t + dt
 	else
-		widget.style.ammo_gained.offset = table.clone(data.offset)
+		widget.style.ammo_gained.offset = table_clone(data.offset)
 		data.display_t = 0
 		data.amount = 0
 		data.alpha_multiplier = 1
@@ -284,239 +290,350 @@ local function display_ammo_gained(dt, widget, data)
 	return widget_cleared
 end
 
-mod:hook_safe("HudElementPlayerWeapon", "update", function(self, _dt, _t, ui_renderer)
-	local uses_ammo = self._uses_ammo and not self._infinite_ammo
-	local ability_type = self._ability and self._ability.ability_type
+local function _element_state(self)
+	if self._numericui_ammo_available then
+		return
+	end
 
-	if not ability_type and not self._uses_weapon_special_charges then
+	local available = {}
+
+	for i = 1, #ammo_gained_widget_templates do
+		available[i] = table_clone(ammo_gained_widget_templates[i])
+	end
+
+	self._numericui_ammo_available = available
+	self._numericui_ammo_active = {}
+	self._numericui_ammo_cumulative = table_clone(ammo_gained_data)
+	self._numericui_grenade = {
+		amount = 0,
+		display_t = 0,
+	}
+end
+
+local function _update_max_ammo_style(self)
+	if not mod.setting("max_ammo_text") then
+		return
+	end
+
+	local max_ammo_font_size = mod.setting("ammo_text_font_size") or AMMO_TEXT_FONT_SIZE_DEFAULT
+	local max_ammo_offset_x = mod.setting("ammo_text_offset_x") or AMMO_TEXT_OFFSET_X_DEFAULT
+	local max_ammo_offset_y = mod.setting("ammo_text_offset_y") or AMMO_TEXT_OFFSET_Y_DEFAULT
+	local widgets_by_name = self._widgets_by_name
+
+	for i = 1, NetworkConstants.clips_in_use.max_size do
+		local ammo_text_widget = widgets_by_name[_ammo_text_widget_names[i]]
+
+		if ammo_text_widget then
+			local style = ammo_text_widget.style
+			local max_ammo_style = style.max_ammo
+			local base_y = style.ammo_amount_4.offset[2]
+
+			-- only touch the style when a setting or the clip counter position changes
+			if
+				max_ammo_style._numericui_font_size ~= max_ammo_font_size
+				or max_ammo_style._numericui_offset_x ~= max_ammo_offset_x
+				or max_ammo_style._numericui_offset_y ~= max_ammo_offset_y
+				or max_ammo_style._numericui_base_y ~= base_y
+			then
+				max_ammo_style._numericui_font_size = max_ammo_font_size
+				max_ammo_style._numericui_offset_x = max_ammo_offset_x
+				max_ammo_style._numericui_offset_y = max_ammo_offset_y
+				max_ammo_style._numericui_base_y = base_y
+				max_ammo_style.font_size = max_ammo_font_size
+				max_ammo_style.default_font_size = max_ammo_font_size
+				max_ammo_style.focused_font_size = max_ammo_font_size
+				max_ammo_style.drop_shadow = true
+				-- anchor from the default font size so changing the font size
+				-- only resizes the text instead of also moving it
+				max_ammo_style.offset[1] = AMMO_TEXT_FONT_SIZE_DEFAULT * 2
+					+ (max_ammo_offset_x - AMMO_TEXT_OFFSET_X_DEFAULT)
+				max_ammo_style.offset[2] = base_y
+					+ AMMO_TEXT_FONT_SIZE_DEFAULT * 1.1
+					+ (max_ammo_offset_y - AMMO_TEXT_OFFSET_Y_DEFAULT)
+				ammo_text_widget.dirty = true
+			end
+		end
+	end
+end
+
+local function _update_max_ammo_text(self, total_current, total_max)
+	local slot_component = self._slot_component
+	local max_reserve = slot_component and slot_component.max_ammunition_reserve
+	local show_max_ammo_text = mod.setting("max_ammo_text")
+	local show_as_percent = show_max_ammo_text and mod.setting("show_max_ammo_as_percent")
+	local widgets_by_name = self._widgets_by_name
+
+	_update_max_ammo_style(self)
+
+	for i = 1, NetworkConstants.clips_in_use.max_size do
+		local ammo_text_widget = widgets_by_name[_ammo_text_widget_names[i]]
+
+		if ammo_text_widget then
+			local content = ammo_text_widget.content
+
+			if show_max_ammo_text and max_reserve then
+				local max_ammo_value
+
+				if show_as_percent then
+					if total_max and total_max > 0 then
+						max_ammo_value = math_floor(math_min(total_current / total_max * 100, 100))
+					else
+						max_ammo_value = 0
+					end
+				else
+					max_ammo_value = max_reserve
+				end
+
+				-- only rebuild the string when the displayed value changes
+				if content._numericui_max_ammo_value ~= max_ammo_value then
+					content._numericui_max_ammo_value = max_ammo_value
+
+					if show_as_percent then
+						content.max_ammo = string_format("%d%%", max_ammo_value)
+					else
+						content.max_ammo = string_format("/%d", max_ammo_value)
+					end
+
+					ammo_text_widget.dirty = true
+				end
+			elseif content.max_ammo ~= "" then
+				content._numericui_max_ammo_value = nil
+				content.max_ammo = ""
+				ammo_text_widget.dirty = true
+			end
+		end
+	end
+
+	self._numericui_max_reserve = max_reserve
+end
+
+local function _update_ammo_icon_color(self, total_current, total_max)
+	if not mod.setting("show_ammo_icon") then
+		return
+	end
+
+	local icon_widget = self._widgets_by_name.ammo_icon
+
+	if not icon_widget then
+		return
+	end
+
+	if icon_widget.content.ammo_icon ~= AMMO_ICON_MATERIAL then
+		icon_widget.content.ammo_icon = AMMO_ICON_MATERIAL
+		icon_widget.dirty = true
+	end
+
+	local weapon_ammo_fraction = 0
+
+	if total_max and total_max > 0 then
+		weapon_ammo_fraction = total_current / total_max
+	end
+
+	local color
+
+	if weapon_ammo_fraction > 0.66 then
+		color = UIHudSettings.color_tint_main_1
+	elseif weapon_ammo_fraction > 0.33 then
+		color = UIHudSettings.color_tint_ammo_low
+	elseif weapon_ammo_fraction > 0 then
+		color = UIHudSettings.color_tint_ammo_medium
+	else
+		color = UIHudSettings.color_tint_ammo_high
+	end
+
+	if color ~= icon_widget.style.ammo_icon.color then
+		icon_widget.style.ammo_icon.color = color
+		icon_widget.dirty = true
+	end
+end
+
+mod:hook_safe("HudElementPlayerWeapon", "_set_ammo_amount", function(self, amount, total_max_amount)
+	-- called once from init with (nil, nil), before any clip data exists
+	if not amount then
+		return
+	end
+
+	local uses_ammo = self._uses_ammo and not self._infinite_ammo
+
+	if not uses_ammo or self._uses_weapon_special_charges then
+		return
+	end
+
+	_element_state(self)
+
+	local show_munitions_gained = mod.setting("show_munitions_gained")
+
+	if self._ability and self._ability.ability_type then
+		-- grenades and other ability charges
+		local prev_charges = self._numericui_prev_grenade or amount
+
+		if show_munitions_gained and amount > prev_charges then
+			local grenade = self._numericui_grenade
+
+			grenade.pending = (grenade.pending or 0) + (amount - prev_charges)
+		end
+
+		self._numericui_prev_grenade = amount
+
+		return
+	end
+
+	local slot_component = self._slot_component
+	local max_reserve = slot_component and slot_component.max_ammunition_reserve
+
+	if not max_reserve or max_reserve <= 0 then
+		return
+	end
+
+	self._numericui_total_current = amount
+	self._numericui_total_max = total_max_amount
+
+	local max_clip = self._max_ammunition_clips[1] or 0
+	self._numericui_ammo_len = max_clip >= 10 and 3 or 2
+
+	_update_max_ammo_text(self, amount, total_max_amount)
+	_update_ammo_icon_color(self, amount, total_max_amount)
+
+	mod._pickup_preview_dirty = true
+
+	local prev_ammo = self._numericui_prev_ammo or amount
+
+	if show_munitions_gained and amount > prev_ammo then
+		self._numericui_pending_ammo_gain = (self._numericui_pending_ammo_gain or 0) + (amount - prev_ammo)
+	end
+
+	self._numericui_prev_ammo = amount
+end)
+
+mod:hook_safe("HudElementPlayerWeapon", "set_wield_anim_progress", function(self, _progress, ui_renderer)
+	_update_max_ammo_style(self)
+
+	local ammo_len = self._numericui_ammo_len
+
+	if not ammo_len or not mod.setting("show_ammo_icon") then
+		return
+	end
+
+	local widgets_by_name = self._widgets_by_name
+	local icon_widget = widgets_by_name.ammo_icon
+	local ammo_text_widget = widgets_by_name.ammo_text_1
+
+	if not icon_widget or not ammo_text_widget then
+		return
+	end
+
+	local amount_style = ammo_text_widget.style.ammo_amount_1
+	local font_size = amount_style.font_size
+	local anchor_x = ammo_text_widget.offset[1]
+	local anchor_y = ammo_text_widget.offset[2]
+
+	if
+		ammo_len == self._numericui_icon_len
+		and font_size == self._numericui_icon_font_size
+		and anchor_x == self._numericui_icon_anchor_x
+		and anchor_y == self._numericui_icon_anchor_y
+	then
+		return
+	end
+
+	self._numericui_icon_len = ammo_len
+	self._numericui_icon_font_size = font_size
+	self._numericui_icon_anchor_x = anchor_x
+	self._numericui_icon_anchor_y = anchor_y
+
+	local text_width, text_height = UIRenderer.text_size(ui_renderer, "0", amount_style.font_type, font_size)
+	local gap_size = font_size * 0.25
+	local icon_size = 12
+	local char_gap = (ammo_len - 1) * gap_size
+
+	icon_widget.offset[1] = anchor_x - ((text_width * ammo_len) + char_gap)
+	icon_widget.offset[2] = anchor_y - text_height + icon_size
+	icon_widget.dirty = true
+end)
+
+local function _step_ammo_gained(self, dt, gained)
+	local widgets_by_name = self._widgets_by_name
+
+	if ammo_gained_cumulative then
+		local data = self._numericui_ammo_cumulative
+
+		if gained then
+			data.amount = data.amount + gained
+			widgets_by_name.ammo_gained_1.content.ammo_gained = "+" .. data.amount
+			data.display_t = (data.display_t + dt) / 2
+		end
+
+		display_ammo_gained(dt, widgets_by_name.ammo_gained_1, data)
+
+		return
+	end
+
+	local available = self._numericui_ammo_available
+	local active = self._numericui_ammo_active
+
+	if gained then
+		local widget_data
+
+		if #available > 0 then
+			widget_data = table_remove(available)
+		else
+			-- If more than 4 widgets are already being shown, we reset and use the oldest one.
+			widget_data = table_remove(active, 1)
+			widget_data.alpha_multiplier = 1
+			widgets_by_name[widget_data.widget_name].style.ammo_gained.offset = table_clone(widget_data.offset)
+		end
+
+		widget_data.display_t = dt
+		widget_data.amount = gained
+		table_insert(active, widget_data)
+		widgets_by_name[widget_data.widget_name].content.ammo_gained = "+" .. widget_data.amount
+	end
+
+	for i = #active, 1, -1 do
+		local widget_data = active[i]
+
+		if display_ammo_gained(dt, widgets_by_name[widget_data.widget_name], widget_data) then
+			table_insert(available, table_remove(active, i))
+		end
+	end
+end
+
+local function _step_grenade_gained(self, dt)
+	local grenade = self._numericui_grenade
+	local widget = self._widgets_by_name.grenade_gained
+
+	if grenade.pending then
+		grenade.amount = grenade.amount + grenade.pending
+		grenade.pending = nil
+		widget.content.grenade_gained = "+" .. grenade.amount
+		grenade.display_t = (grenade.display_t + dt) / 2
+	end
+
+	display_grenade_gained(dt, widget, grenade)
+end
+
+mod:hook_safe("HudElementPlayerWeapon", "update", function(self, dt)
+	local cached_max_reserve = self._numericui_max_reserve
+
+	if cached_max_reserve then
 		local slot_component = self._slot_component
 
-		if slot_component and uses_ammo then
-			local max_reserve = slot_component.max_ammunition_reserve
-			if not max_reserve or max_reserve <= 0 then
-				return
-			end
-			local any_clip_in_use = Ammo.clips_in_use(slot_component, _clips_in_use_scratch)
-
-			if not any_clip_in_use then
-				return
-			end
-
-			local icon_widget = self._widgets_by_name.ammo_icon
-
-			local max_reserve = Ammo.max_ammo_in_reserve(slot_component) or 0
-			local current_reserve = Ammo.current_ammo_in_reserve(slot_component) or 0
-			local total_current_ammo = current_reserve
-			local total_max_ammo = max_reserve
-
-			local ammo_len = 2
-			local ammo_icon_size = HudElementTeamPlayerPanelSettings.ammo_size
-			local ammo_icon_font_type = "machine_medium"
-			local ammo_icon_offset_x = 0
-			local ammo_icon_offset_y = 0
-
-			local show_max_ammo_text = mod:get("max_ammo_text")
-			local show_max_ammo_as_percent = mod:get("show_max_ammo_as_percent")
-
-			local max_ammo_font_size, max_ammo_offset_x, max_ammo_offset_y
-			if show_max_ammo_text then
-				max_ammo_font_size = mod:get("ammo_text_font_size") or AMMO_TEXT_FONT_SIZE_DEFAULT
-				max_ammo_offset_x = mod:get("ammo_text_offset_x") or AMMO_TEXT_OFFSET_X_DEFAULT
-				max_ammo_offset_y = mod:get("ammo_text_offset_y") or AMMO_TEXT_OFFSET_Y_DEFAULT
-			end
-
-			for i = 1, NetworkConstants.clips_in_use.max_size do
-				local widget_name = _ammo_text_widget_names[i]
-				if not widget_name then
-					widget_name = "ammo_text_" .. i
-					_ammo_text_widget_names[i] = widget_name
-				end
-
-				local ammo_text_widget = self._widgets_by_name[widget_name]
-				local max_clip = Ammo.max_ammo_in_clips(slot_component, i) or 0
-				local current_clip = Ammo.current_ammo_in_clips(slot_component, i) or 0
-
-				if i == 1 then
-					ammo_len = max_clip >= 10 and 3 or 2
-					ammo_icon_size = ammo_text_widget.style.ammo_amount_1.font_size
-					ammo_icon_font_type = ammo_text_widget.style.ammo_amount_1.font_type
-					ammo_icon_offset_x = ammo_text_widget.offset[1]
-					ammo_icon_offset_y = ammo_text_widget.offset[2]
-				end
-
-				total_current_ammo = current_clip + total_current_ammo
-				total_max_ammo = max_clip + total_max_ammo
-
-				if ammo_text_widget then
-					local content = ammo_text_widget.content
-					local style = ammo_text_widget.style
-
-					if show_max_ammo_text and max_reserve then
-						local max_ammo_style = style.max_ammo
-						local base_y = style.ammo_amount_4.offset[2]
-
-						-- only touch the style when a setting or the clip counter position changes
-						if
-							max_ammo_style._numericui_font_size ~= max_ammo_font_size
-							or max_ammo_style._numericui_offset_x ~= max_ammo_offset_x
-							or max_ammo_style._numericui_offset_y ~= max_ammo_offset_y
-							or max_ammo_style._numericui_base_y ~= base_y
-						then
-							max_ammo_style._numericui_font_size = max_ammo_font_size
-							max_ammo_style._numericui_offset_x = max_ammo_offset_x
-							max_ammo_style._numericui_offset_y = max_ammo_offset_y
-							max_ammo_style._numericui_base_y = base_y
-							max_ammo_style.font_size = max_ammo_font_size
-							max_ammo_style.default_font_size = max_ammo_font_size
-							max_ammo_style.focused_font_size = max_ammo_font_size
-							max_ammo_style.drop_shadow = true
-							-- anchor from the default font size so changing the font size
-							-- only resizes the text instead of also moving it
-							max_ammo_style.offset[1] = AMMO_TEXT_FONT_SIZE_DEFAULT * 2
-								+ (max_ammo_offset_x - AMMO_TEXT_OFFSET_X_DEFAULT)
-							max_ammo_style.offset[2] = base_y
-								+ AMMO_TEXT_FONT_SIZE_DEFAULT * 1.1
-								+ (max_ammo_offset_y - AMMO_TEXT_OFFSET_Y_DEFAULT)
-							ammo_text_widget.dirty = true
-						end
-
-						local max_ammo_value
-						if show_max_ammo_as_percent then
-							max_ammo_value = math.floor(math.min(total_current_ammo / total_max_ammo * 100, 100))
-						else
-							max_ammo_value = max_reserve
-						end
-
-						-- only rebuild the string when the displayed value changes
-						if content._numericui_max_ammo_value ~= max_ammo_value then
-							content._numericui_max_ammo_value = max_ammo_value
-
-							if show_max_ammo_as_percent then
-								content.max_ammo = string.format("%d%%", max_ammo_value)
-							else
-								content.max_ammo = string.format("/%d", max_ammo_value)
-							end
-
-							ammo_text_widget.dirty = true
-						end
-					elseif content.max_ammo ~= "" then
-						content._numericui_max_ammo_value = nil
-						content.max_ammo = ""
-						ammo_text_widget.dirty = true
-					end
-				end
-			end
-
-			if mod:get("show_ammo_icon") and icon_widget and max_reserve then
-				icon_widget.content.ammo_icon = "content/ui/materials/hud/icons/party_ammo"
-
-				local color = nil
-				local weapon_ammo_fraction = 0
-
-				if total_max_ammo > 0 then
-					weapon_ammo_fraction = total_current_ammo / total_max_ammo
-				end
-
-				if weapon_ammo_fraction > 0.66 then
-					color = UIHudSettings.color_tint_main_1
-				elseif weapon_ammo_fraction > 0.33 then
-					color = UIHudSettings.color_tint_ammo_low
-				elseif weapon_ammo_fraction > 0 then
-					color = UIHudSettings.color_tint_ammo_medium
-				else
-					color = UIHudSettings.color_tint_ammo_high
-				end
-
-				if color ~= icon_widget.style.ammo_icon.color then
-					icon_widget.style.ammo_icon.color = color
-					icon_widget.dirty = true
-				end
-
-				local font_size = ammo_icon_size
-				if ammo_len ~= prev_clip_ammo_char_len or prev_font_size ~= font_size then
-					local font_type = ammo_icon_font_type
-					local text_width, text_height = UIRenderer.text_size(ui_renderer, "0", font_type, font_size)
-					local gap_size = font_size * 0.25
-					local icon_size = 12
-					local char_gap = (ammo_len - 1) * gap_size
-					local x_offset = ammo_icon_offset_x - ((text_width * ammo_len) + char_gap)
-					local y_offset = ammo_icon_offset_y - text_height + icon_size
-
-					icon_widget.offset[1] = x_offset
-					icon_widget.offset[2] = y_offset
-
-					icon_widget.dirty = true
-					prev_clip_ammo_char_len = ammo_len
-					prev_font_size = font_size
-				end
-			end
-
-			if mod:get("show_munitions_gained") then --this one checks for ammo gained
-				local total_ammo = self._total_ammo
-				-- a fresh element (mission start or HUD recreation after a settings
-				-- change) has no previous value yet; treat the current total as the
-				-- baseline so the full ammo pool is not reported as gained
-				local prev_ammo = self._prev_ammo or total_ammo
-
-				if ammo_gained_cumulative then
-					local ammo_gained_widget = self._widgets_by_name.ammo_gained_1
-
-					if total_ammo > prev_ammo then
-						ammo_gained_data.amount = total_ammo - prev_ammo + ammo_gained_data.amount
-						ammo_gained_widget.content.ammo_gained = "+" .. ammo_gained_data.amount
-						ammo_gained_data.display_t = (ammo_gained_data.display_t + _dt) / 2
-					end
-
-					display_ammo_gained(_dt, self._widgets_by_name["ammo_gained_1"], ammo_gained_data)
-				else
-					if total_ammo > prev_ammo then
-						local widget_data
-
-						if #ammo_gained_available_widgets > 0 then
-							widget_data = table.remove(ammo_gained_available_widgets)
-						else
-							widget_data = table.remove(ammo_gained_active_widgets, 1) -- If more than 4 widgets are already being shown, we reset and use the oldest one.
-							widget_data.alpha_multiplier = 1
-							self._widgets_by_name[widget_data.widget_name].style.ammo_gained.offset =
-								table.clone(widget_data.offset)
-						end
-
-						widget_data.display_t = _dt
-						widget_data.amount = total_ammo - prev_ammo
-						table.insert(ammo_gained_active_widgets, widget_data)
-						self._widgets_by_name[widget_data.widget_name].content.ammo_gained = "+" .. widget_data.amount
-					end
-
-					for i = #ammo_gained_active_widgets, 1, -1 do
-						local ammo_gained_widget = self._widgets_by_name[ammo_gained_active_widgets[i].widget_name]
-
-						local widget_cleared = display_ammo_gained(
-							_dt,
-							self._widgets_by_name[ammo_gained_active_widgets[i].widget_name],
-							ammo_gained_active_widgets[i]
-						)
-
-						if widget_cleared then
-							local widget_temp = table.remove(ammo_gained_active_widgets, i)
-							table.insert(ammo_gained_available_widgets, widget_temp)
-						end
-					end
-				end
-
-				self._prev_ammo = total_ammo
-			end
+		if slot_component and slot_component.max_ammunition_reserve ~= cached_max_reserve then
+			_update_max_ammo_text(self, self._numericui_total_current, self._numericui_total_max)
 		end
-	elseif mod:get("show_munitions_gained") and uses_ammo and not self._uses_weapon_special_charges then --This one checks for grenades gained
-		local grenade_gained_widget = self._widgets_by_name.grenade_gained
-		local total_ammo = self._total_ammo
+	end
 
-		if total_ammo > prev_grenade_charges then
-			grenade_gained_amount = total_ammo - prev_grenade_charges + grenade_gained_amount
-			grenade_gained_widget.content.grenade_gained = "+" .. grenade_gained_amount
-			grenade_gained_display_t = (grenade_gained_display_t + _dt) / 2
-		end
+	local gained = self._numericui_pending_ammo_gain
+	local active = self._numericui_ammo_active
 
-		display_grenade_gained(_dt, self._widgets_by_name.grenade_gained)
-		prev_grenade_charges = total_ammo
+	if gained or (active and #active > 0) then
+		self._numericui_pending_ammo_gain = nil
+		_step_ammo_gained(self, dt, gained)
+	end
+
+	local grenade = self._numericui_grenade
+
+	if grenade and (grenade.pending or grenade.amount ~= 0) then
+		_step_grenade_gained(self, dt)
 	end
 end)

--- a/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
+++ b/NumericUI/scripts/mods/NumericUI/TeamPlayerPanel.lua
@@ -10,7 +10,14 @@ local HudElementTeamPlayerPanelSettings =
 	require("scripts/ui/hud/elements/team_player_panel/hud_element_team_player_panel_settings")
 local UIHudSettings = require("scripts/settings/ui/ui_hud_settings")
 local UIFontSettings = require("scripts/managers/ui/ui_font_settings")
-local FixedFrame = require("scripts/utilities/fixed_frame")
+
+local math_clamp = math.clamp
+local math_floor = math.floor
+local math_huge = math.huge
+local math_round = math.round
+local string_format = string.format
+local table_clone = table.clone
+local table_merge_recursive = table.merge_recursive
 
 local bar_size = HudElementTeamPlayerPanelSettings.size
 local hud_body_font_setting_name = "hud_body"
@@ -40,12 +47,13 @@ local tough_text_style = {
 	offset = { 0, -6, 2 },
 }
 
-local ability_max_cooldown = {} -- "player ID -> max cooldown"
-local ability_cooldown_timer = {} -- "player ID -> cooldown timer"
 local ability_bar_cooldown_color = Color.terminal_background_gradient_selected(255, true)
+local ABILITY_TYPE = "combat_ability"
+
+local AMMO_UPDATE_INTERVAL = 0.1
 
 mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
-	if mod:get("health_text") or mod:get("toughness_text") then
+	if mod.setting("health_text") or mod.setting("toughness_text") then
 		instance.widget_definitions.coherency_indicator = UIWidget.create_definition({
 			{
 				value = "content/ui/materials/hud/icons/party_cohesion",
@@ -65,14 +73,14 @@ mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 			backups.team_hud_definitions.widget_definitions.coherency_indicator
 	end
 
-	if mod:get("ability_cd_text") then
+	if mod.setting("ability_cd_text") then
 		instance.widget_definitions.ability_text = UIWidget.create_definition({
 			{
 				value_id = "text",
 				style_id = "text",
 				pass_type = "text",
 				value = "",
-				style = table.merge_recursive(table.clone(tough_text_style), {
+				style = table_merge_recursive(table_clone(tough_text_style), {
 					text_color = UIHudSettings.color_tint_secondary_1,
 					default_color = UIHudSettings.color_tint_secondary_1,
 					dimmed_color = UIHudSettings.color_tint_secondary_3,
@@ -85,7 +93,7 @@ mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 		instance.widget_definitions.ability_text = nil
 	end
 
-	if mod:get("ability_cd_bar") then
+	if mod.setting("ability_cd_bar") then
 		instance.widget_definitions.ability_bar = UIWidget.create_definition({
 			{
 				value = "content/ui/materials/backgrounds/default_square",
@@ -124,7 +132,7 @@ mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 		instance.widget_definitions.ability_bar = nil
 	end
 
-	if mod:get("ammo_text") or mod:get("peril_icon") then
+	if mod.setting("ammo_text") or mod.setting("peril_icon") then
 		instance.widget_definitions.numeric_ui_peril_icon = UIWidget.create_definition({
 			{
 				value_id = "icon_text",
@@ -150,7 +158,7 @@ mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 		instance.widget_definitions.numeric_ui_peril_icon = nil
 	end
 
-	if mod:get("ammo_text") then
+	if mod.setting("ammo_text") then
 		instance.widget_definitions.numeric_ui_ammo_text = UIWidget.create_definition({
 			{
 				value_id = "text",
@@ -175,14 +183,14 @@ mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 		instance.widget_definitions.numeric_ui_ammo_text = nil
 	end
 
-	if mod:get("health_text") then
+	if mod.setting("health_text") then
 		instance.widget_definitions.health_text = UIWidget.create_definition({
 			{
 				value_id = "text_3",
 				style_id = "text_3",
 				pass_type = "text",
 				value = "0",
-				style = table.merge_recursive(table.clone(health_text_style), {
+				style = table_merge_recursive(table_clone(health_text_style), {
 					index = 3,
 					text_color = UIHudSettings.color_tint_main_1,
 					default_color = UIHudSettings.color_tint_main_1,
@@ -195,7 +203,7 @@ mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 				style_id = "text_2",
 				pass_type = "text",
 				value = "0",
-				style = table.merge_recursive(table.clone(health_text_style), {
+				style = table_merge_recursive(table_clone(health_text_style), {
 					index = 2,
 					text_color = UIHudSettings.color_tint_main_1,
 					default_color = UIHudSettings.color_tint_main_1,
@@ -208,7 +216,7 @@ mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 				style_id = "text_1",
 				pass_type = "text",
 				value = "0",
-				style = table.merge_recursive(table.clone(health_text_style), {
+				style = table_merge_recursive(table_clone(health_text_style), {
 					index = 1,
 					text_color = UIHudSettings.color_tint_main_1,
 					default_color = UIHudSettings.color_tint_main_1,
@@ -221,14 +229,14 @@ mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 		instance.widget_definitions.health_text = nil
 	end
 
-	if mod:get("toughness_text") then
+	if mod.setting("toughness_text") then
 		instance.widget_definitions.toughness_text = UIWidget.create_definition({
 			{
 				value_id = "text_3",
 				style_id = "text_3",
 				pass_type = "text",
 				value = "0",
-				style = table.merge_recursive(table.clone(tough_text_style), {
+				style = table_merge_recursive(table_clone(tough_text_style), {
 					index = 3,
 					text_color = UIHudSettings.color_tint_6,
 					default_color = UIHudSettings.color_tint_6,
@@ -241,7 +249,7 @@ mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 				style_id = "text_2",
 				pass_type = "text",
 				value = "0",
-				style = table.merge_recursive(table.clone(tough_text_style), {
+				style = table_merge_recursive(table_clone(tough_text_style), {
 					index = 2,
 					text_color = UIHudSettings.color_tint_6,
 					default_color = UIHudSettings.color_tint_6,
@@ -254,7 +262,7 @@ mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 				style_id = "text_1",
 				pass_type = "text",
 				value = "0",
-				style = table.merge_recursive(table.clone(tough_text_style), {
+				style = table_merge_recursive(table_clone(tough_text_style), {
 					index = 1,
 					text_color = UIHudSettings.color_tint_6,
 					default_color = UIHudSettings.color_tint_6,
@@ -268,16 +276,10 @@ mod:hook_require(TEAM_HUD_DEF_PATH, function(instance)
 	end
 end)
 
-local function update_numericui_ability_cd(self, player, ability_bar_widget, ability_text_widget, ability_component, dt)
-	local player_name = player:name()
-
-	if not ability_cooldown_timer[player_name] then
-		ability_cooldown_timer[player_name] = 0
-	end
-
+local function update_numericui_ability_cd(self, ability_extension, ability_bar_widget, ability_text_widget)
 	local hide_widgets = (self._show_as_dead or self._dead or self._hogtied)
-	local show_ability_text = (mod:get("ability_cd_text") and ability_text_widget)
-	local show_ability_bar = (mod:get("ability_cd_bar") and ability_bar_widget)
+	local show_ability_text = (mod.setting("ability_cd_text") and ability_text_widget)
+	local show_ability_bar = (mod.setting("ability_cd_bar") and ability_bar_widget)
 
 	if hide_widgets then
 		if show_ability_text then
@@ -293,126 +295,175 @@ local function update_numericui_ability_cd(self, player, ability_bar_widget, abi
 		return
 	end
 
-	local cooldown_timer = ability_cooldown_timer[player_name]
+	local remaining_charges = ability_extension:remaining_ability_charges(ABILITY_TYPE)
 
-	if ability_component.num_charges > 0 and cooldown_timer > 0 then
-		ability_cooldown_timer[player_name] = 0
-
-		if show_ability_text then
+	if remaining_charges > 0 then
+		if show_ability_text and ability_text_widget.visible then
 			ability_text_widget.visible = false
+			ability_text_widget.content._numericui_last_value = nil
 			ability_text_widget.dirty = true
 		end
 
 		if show_ability_bar then
-			ability_bar_widget.style.texture.color = UIHudSettings.color_tint_secondary_1
-			ability_bar_widget.style.texture.size[1] = bar_size[1]
-			ability_bar_widget.dirty = true
-		end
-	elseif ability_component.num_charges > 0 and cooldown_timer == 0 then
-		if show_ability_text then
-			if show_ability_text.visible then
-				show_ability_text.visible = false
-				show_ability_text.dirty = true
-			end
-		end
+			local texture_style = ability_bar_widget.style.texture
 
-		if show_ability_bar then
 			if not ability_bar_widget.visible then
 				ability_bar_widget.visible = true
 				ability_bar_widget.dirty = true
 			end
 
-			if ability_bar_widget.style.texture.size[1] ~= bar_size[1] then
-				ability_bar_widget.style.texture.color = UIHudSettings.color_tint_secondary_1
-				ability_bar_widget.style.texture.size[1] = bar_size[1]
+			if texture_style.size[1] ~= bar_size[1] or texture_style.color ~= UIHudSettings.color_tint_secondary_1 then
+				texture_style.color = UIHudSettings.color_tint_secondary_1
+				texture_style.size[1] = bar_size[1]
 				ability_bar_widget.dirty = true
 			end
 		end
-	elseif (cooldown_timer == 0) or (cooldown_timer > ability_max_cooldown[player_name]) then
-		local fixed_frame_t = FixedFrame.get_latest_fixed_time()
-		local time_remaining = math.max(ability_component.cooldown - fixed_frame_t, 0)
-		ability_max_cooldown[player_name] = time_remaining
-		ability_cooldown_timer[player_name] = dt
 
-		if show_ability_text then
+		return
+	end
+
+	local time_remaining = ability_extension:remaining_ability_cooldown(ABILITY_TYPE)
+
+	if not time_remaining or time_remaining == math_huge then
+		time_remaining = 0
+	end
+
+	local max_cooldown = ability_extension:max_ability_cooldown(ABILITY_TYPE) or 0
+
+	if show_ability_text then
+		local content = ability_text_widget.content
+		local display_value = math_floor(time_remaining)
+
+		if not ability_text_widget.visible then
 			ability_text_widget.visible = true
-			ability_text_widget.content.text = string.format("%03d", time_remaining)
-			ability_text_widget.content._numericui_last_value = math.floor(time_remaining)
 			ability_text_widget.dirty = true
 		end
 
-		if show_ability_bar then
-			ability_bar_widget.style.texture.color = ability_bar_cooldown_color
-			ability_bar_widget.style.texture.size[1] = bar_size[1] * (dt / time_remaining)
+		-- only re-render the text when the displayed value changes
+		if content._numericui_last_value ~= display_value then
+			content._numericui_last_value = display_value
+
+			local text = string_format("%03d", time_remaining)
+
+			if content.text ~= text then
+				content.text = text
+				ability_text_widget.dirty = true
+			end
+		end
+	end
+
+	if show_ability_bar then
+		local texture_style = ability_bar_widget.style.texture
+		local cd_progress = max_cooldown > 0 and math_clamp((max_cooldown - time_remaining) / max_cooldown, 0, 1) or 1
+		-- quantize to whole pixels so the retained bar only re-renders when it visibly grows
+		local bar_width = math_floor(bar_size[1] * cd_progress + 0.5)
+
+		if not ability_bar_widget.visible then
 			ability_bar_widget.visible = true
 			ability_bar_widget.dirty = true
 		end
-	elseif cooldown_timer > 0 then
-		cooldown_timer = cooldown_timer + dt
-		ability_cooldown_timer[player_name] = cooldown_timer
 
-		if show_ability_text then
-			local cd_timer = math.max(ability_max_cooldown[player_name] - cooldown_timer, 0)
-			local content = ability_text_widget.content
-			local display_value = math.floor(cd_timer)
-
-			-- only re-render the text when the displayed value changes
-			if content._numericui_last_value ~= display_value then
-				content._numericui_last_value = display_value
-				local text = string.format("%03d", cd_timer)
-
-				if content.text ~= text then
-					content.text = text
-					ability_text_widget.dirty = true
-				end
-			end
-		end
-
-		if show_ability_bar then
-			local texture_style = ability_bar_widget.style.texture
+		if texture_style.size[1] ~= bar_width or texture_style.color ~= ability_bar_cooldown_color then
 			texture_style.color = ability_bar_cooldown_color
-
-			local cd_progress = math.clamp(cooldown_timer / ability_max_cooldown[player_name], 0, 1.0)
-			-- quantize to whole pixels so the retained bar only re-renders when it visibly grows
-			local bar_width = math.floor(bar_size[1] * cd_progress + 0.5)
-
-			if texture_style.size[1] ~= bar_width then
-				texture_style.size[1] = bar_width
-				ability_bar_widget.dirty = true
-			end
+			texture_style.size[1] = bar_width
+			ability_bar_widget.dirty = true
 		end
 	end
 end
 
 mod:hook_safe("HudElementPlayerPanelBase", "destroy", function(self)
-	local player_extensions = self:_player_extensions(self._data.player)
-
-	if mod:get("ability_cd_bar") or mod:get("ability_cd_text") then
+	if mod.setting("ability_cd_text") then
 		local ability_text_widget = self._widgets_by_name.ability_text
+
+		if ability_text_widget then
+			ability_text_widget.visible = false
+			ability_text_widget.dirty = true
+		end
+	end
+
+	if mod.setting("ability_cd_bar") then
 		local ability_bar_widget = self._widgets_by_name.ability_bar
 
-		if player_extensions then
-			local unit_data_extension = player_extensions.unit_data
-			if unit_data_extension then
-				local ability_component = unit_data_extension:read_component("combat_ability")
-				ability_cooldown_timer[self._data.player:name()] = nil
-				if ability_component then
-					ability_max_cooldown[self._data.player:name()] = nil
-				end
-			end
-		end
-
-		if mod:get("ability_cd_text") and ability_text_widget then
-			self._widgets_by_name.ability_text.visible = false
-			self._widgets_by_name.ability_text.dirty = true
-		end
-
-		if mod:get("ability_cd_bar") and ability_bar_widget then
-			self._widgets_by_name.ability_bar_widget.visible = false
-			self._widgets_by_name.ability_bar_widget.dirty = true
+		if ability_bar_widget then
+			ability_bar_widget.visible = false
+			ability_bar_widget.dirty = true
 		end
 	end
 end)
+
+local function update_numericui_ammo(self, unit_data_extension, ammo_text_widget, peril_icon_widget)
+	local peril_color = nil
+	local warp_charge_level = nil
+
+	if peril_icon_widget and peril_icon_widget.visible then
+		local warp_charge_component = unit_data_extension:read_component("warp_charge")
+		warp_charge_level = warp_charge_component.current_percentage
+
+		if warp_charge_level > 0.98 then
+			peril_color = UIHudSettings.color_tint_ammo_high
+		elseif warp_charge_level > 0.75 then
+			peril_color = UIHudSettings.color_tint_ammo_medium
+		elseif warp_charge_level > 0.5 then
+			peril_color = UIHudSettings.color_tint_ammo_low
+		else
+			peril_color = peril_icon_widget.style.icon_text.default_text_color
+		end
+
+		if mod.setting("peril_icon") and peril_color ~= peril_icon_widget.style.icon_text.text_color then
+			peril_icon_widget.style.icon_text.text_color = peril_color
+			peril_icon_widget.dirty = true
+		end
+	end
+
+	local weapon_slots = self._weapon_slots
+	local total_current_ammo = 0
+	local total_max_ammo = 0
+
+	for i = 1, #weapon_slots do
+		local slot_id = weapon_slots[i]
+		local inventory_component = unit_data_extension:read_component(slot_id)
+
+		if inventory_component then
+			local max_clip = Ammo.max_ammo_in_clips(inventory_component) or 0
+			local max_reserve = Ammo.max_ammo_in_reserve(inventory_component) or 0
+			local current_clip = Ammo.current_ammo_in_clips(inventory_component) or 0
+			local current_reserve = Ammo.current_ammo_in_reserve(inventory_component) or 0
+			total_current_ammo = total_current_ammo + current_clip + current_reserve
+			total_max_ammo = total_max_ammo + max_clip + max_reserve
+		end
+	end
+
+	local show_as_empty = total_max_ammo == 0 or self._show_as_dead or self._dead or self._hogtied
+
+	-- only re-render the retained widget when the displayed values change
+	if
+		total_current_ammo ~= self._numericui_ammo_current
+		or total_max_ammo ~= self._numericui_ammo_max
+		or show_as_empty ~= self._numericui_ammo_empty
+	then
+		self._numericui_ammo_current = total_current_ammo
+		self._numericui_ammo_max = total_max_ammo
+		self._numericui_ammo_empty = show_as_empty
+
+		if show_as_empty then
+			-- No ammo or dead
+			ammo_text_widget.content.text = ""
+		elseif total_max_ammo == 0 and (peril_icon_widget and peril_icon_widget.visible) and mod.setting("peril_text") then
+			-- Ammo text as peril percent
+			ammo_text_widget.content.text = string_format("%1d%%", math_round(warp_charge_level * 100))
+			ammo_text_widget.style.text.text_color = peril_color
+		else
+			-- Ammo
+			if mod.setting("ammo_as_percent") then
+				ammo_text_widget.content.text = string_format("%1d%%", (total_current_ammo / total_max_ammo) * 100)
+			else
+				ammo_text_widget.content.text = string_format("%1d/%1d", total_current_ammo, total_max_ammo)
+			end
+			ammo_text_widget.style.text.text_color = self._widgets_by_name.ammo_status.style.ammo.color
+		end
+		ammo_text_widget.dirty = true
+	end
+end
 
 local function update_numericui_player_features(func, self, dt, t, player, ui_renderer)
 	func(self, dt, t, player, ui_renderer)
@@ -422,99 +473,26 @@ local function update_numericui_player_features(func, self, dt, t, player, ui_re
 	local extensions = self:_player_extensions(player)
 	local unit_data_extension = extensions and extensions.unit_data
 
-	if ammo_text_widget then
-		local peril_color = nil
-		local warp_charge_level = nil
+	if ammo_text_widget and unit_data_extension then
+		local elapsed = (self._numericui_ammo_t or AMMO_UPDATE_INTERVAL) + dt
 
-		if unit_data_extension then
-			if peril_icon_widget and peril_icon_widget.visible then
-				local warp_charge_component = unit_data_extension:read_component("warp_charge")
-				warp_charge_level = warp_charge_component.current_percentage
-
-				if warp_charge_level > 0.98 then
-					peril_color = UIHudSettings.color_tint_ammo_high
-				elseif warp_charge_level > 0.75 then
-					peril_color = UIHudSettings.color_tint_ammo_medium
-				elseif warp_charge_level > 0.5 then
-					peril_color = UIHudSettings.color_tint_ammo_low
-				else
-					peril_color = peril_icon_widget.style.icon_text.default_text_color
-				end
-
-				if mod:get("peril_icon") and peril_color ~= peril_icon_widget.style.icon_text.text_color then
-					peril_icon_widget.style.icon_text.text_color = peril_color
-					peril_icon_widget.dirty = true
-				end
-			end
-
-			local weapon_slots = self._weapon_slots
-			local total_current_ammo = 0
-			local total_max_ammo = 0
-
-			for i = 1, #weapon_slots do
-				local slot_id = weapon_slots[i]
-				local inventory_component = unit_data_extension:read_component(slot_id)
-
-				if inventory_component then
-					local max_clip = Ammo.max_ammo_in_clips(inventory_component) or 0
-					local max_reserve = Ammo.max_ammo_in_reserve(inventory_component) or 0
-					local current_clip = Ammo.current_ammo_in_clips(inventory_component) or 0
-					local current_reserve = Ammo.current_ammo_in_reserve(inventory_component) or 0
-					total_current_ammo = total_current_ammo + current_clip + current_reserve
-					total_max_ammo = total_max_ammo + max_clip + max_reserve
-				end
-			end
-
-			local show_as_empty = total_max_ammo == 0 or self._show_as_dead or self._dead or self._hogtied
-
-			-- only re-render the retained widget when the displayed values change
-			if
-				total_current_ammo ~= self._numericui_ammo_current
-				or total_max_ammo ~= self._numericui_ammo_max
-				or show_as_empty ~= self._numericui_ammo_empty
-			then
-				self._numericui_ammo_current = total_current_ammo
-				self._numericui_ammo_max = total_max_ammo
-				self._numericui_ammo_empty = show_as_empty
-
-				if show_as_empty then
-					-- No ammo or dead
-					ammo_text_widget.content.text = ""
-				elseif
-					total_max_ammo == 0
-					and (peril_icon_widget and peril_icon_widget.visible)
-					and mod:get("peril_text")
-				then
-					-- Ammo text as peril percent
-					ammo_text_widget.content.text = string.format("%1d%%", math.round(warp_charge_level * 100))
-					ammo_text_widget.style.text.text_color = peril_color
-				else
-					-- Ammo
-					if mod:get("ammo_as_percent") then
-						ammo_text_widget.content.text =
-							string.format("%1d%%", (total_current_ammo / total_max_ammo) * 100)
-					else
-						ammo_text_widget.content.text = string.format("%1d/%1d", total_current_ammo, total_max_ammo)
-					end
-					ammo_text_widget.style.text.text_color = self._widgets_by_name.ammo_status.style.ammo.color
-				end
-				ammo_text_widget.dirty = true
-			end
+		if elapsed >= AMMO_UPDATE_INTERVAL then
+			self._numericui_ammo_t = 0
+			update_numericui_ammo(self, unit_data_extension, ammo_text_widget, peril_icon_widget)
+		else
+			self._numericui_ammo_t = elapsed
 		end
 	end
 
-	if mod:get("ability_cd_text") or mod:get("ability_cd_bar") then
-		if extensions then
-			local ability_component = unit_data_extension:read_component("combat_ability")
-			update_numericui_ability_cd(
-				self,
-				player,
-				self._widgets_by_name.ability_bar,
-				self._widgets_by_name.ability_text,
-				ability_component,
-				dt
-			)
-		end
+	local ability_extension = extensions and extensions.ability
+
+	if ability_extension and (mod.setting("ability_cd_text") or mod.setting("ability_cd_bar")) then
+		update_numericui_ability_cd(
+			self,
+			ability_extension,
+			self._widgets_by_name.ability_bar,
+			self._widgets_by_name.ability_text
+		)
 	end
 end
 
@@ -522,9 +500,9 @@ mod:hook("HudElementPersonalPlayerPanel", "_update_player_features", update_nume
 mod:hook("HudElementTeamPlayerPanel", "_update_player_features", update_numericui_player_features)
 
 mod:hook("HudElementTeamPlayerPanel", "init", function(func, self, _parent, _draw_layer, _start_scale, data)
-	HudElementTeamPlayerPanelSettings.feature_list.health_text = mod:get("health_text")
-	HudElementTeamPlayerPanelSettings.feature_list.toughness_text = mod:get("toughness_text")
-	HudElementTeamPlayerPanelSettings.feature_list.level = mod:get("level")
+	HudElementTeamPlayerPanelSettings.feature_list.health_text = mod.setting("health_text")
+	HudElementTeamPlayerPanelSettings.feature_list.toughness_text = mod.setting("toughness_text")
+	HudElementTeamPlayerPanelSettings.feature_list.level = mod.setting("level")
 
 	func(self, _parent, _draw_layer, _start_scale, data)
 
@@ -533,24 +511,13 @@ mod:hook("HudElementTeamPlayerPanel", "init", function(func, self, _parent, _dra
 	if player_extensions then
 		local unit_data_extension = player_extensions.unit_data
 		if unit_data_extension then
-			if mod:get("ability_cd_bar") or mod:get("ability_cd_text") then
-				local ability_component = unit_data_extension:read_component("combat_ability")
-				ability_cooldown_timer[data.player:name()] = 0
-				if ability_component then
-					local time = Managers.time:time("gameplay")
-					local time_remaining = ability_component.cooldown - time
-
-					ability_max_cooldown[data.player:name()] = time_remaining
-				end
-			end
-
 			local archetype = unit_data_extension:archetype_name()
 			local peril_icon_widget = self._widgets_by_name.numeric_ui_peril_icon
 
-			if mod:get("peril_icon") then
-				peril_icon_widget.content.icon_text = "" -- this boxed questionmark is the character for the peril icon
+			if mod.setting("peril_icon") then
+				peril_icon_widget.content.icon_text = "" -- this boxed questionmark is the character for the peril icon
 				peril_icon_widget.visible = (archetype == "psyker")
-			elseif mod:get("ammo_text") then
+			elseif mod.setting("ammo_text") then
 				peril_icon_widget.content.icon_text = ""
 				peril_icon_widget.visible = (archetype == "psyker") -- I use the "visible" flag to determine if it's a psyker
 			end

--- a/NumericUI/scripts/mods/NumericUI/utils.lua
+++ b/NumericUI/scripts/mods/NumericUI/utils.lua
@@ -1,8 +1,27 @@
 local mod = get_mod("NumericUI")
 
+local table_clear = table.clear
+
 mod._is_in_hub = function()
 	local game_mode_name = Managers.state.game_mode:game_mode_name()
 	local is_in_hub = game_mode_name == "hub"
 
 	return is_in_hub
+end
+
+local setting_values = {}
+local setting_cached = {}
+
+mod.setting = function(setting_id)
+	if not setting_cached[setting_id] then
+		setting_values[setting_id] = mod:get(setting_id)
+		setting_cached[setting_id] = true
+	end
+
+	return setting_values[setting_id]
+end
+
+mod.flush_settings = function()
+	table_clear(setting_values)
+	table_clear(setting_cached)
 end


### PR DESCRIPTION
NumericUI hung nearly all of its work off HudElement update hooks, so every rendered frame it re-derived state that vanilla had already computed and cached, or that only changes on discrete events. Profiling a mission showed the mod spending 39.4 microseconds per HUD frame in its own Lua, with the full ammo component scan running 300,997 times and the ammo pickup preview recalculating 80,244 times.

Underpinning the rest, utils.lua gains a lazy settings memo flushed from on_setting_changed. DMF's mod:get resolves the mod name and clones table values on every call, and NumericUI issued roughly sixty per frame: twenty-one in the dodge HUD and twenty-two per team panel, four panels deep. Every DMF option widget commits through mod:set(id, value, true), so flushing on that event is sufficient to keep the memo correct.

PlayerWeapon moves off update onto _set_ammo_amount, which vanilla calls exactly when self._total_ammo or a clip changes, having already populated _current_ammunition_clips and _max_ammunition_clips. The ammo icon is positioned from set_wield_anim_progress instead, because the icon anchors off the clip counter's font size and offset and vanilla rewrites both there; it also calls that method immediately after _set_ammo_amount whenever clip information changed, so the icon never lags the numbers. What remains in update is stepping the floating "+N" animations, which genuinely need a delta time, plus a single field read watching for a max reserve change that _set_ammo_amount would not report. The ammo scan now runs 1,257 times instead of 300,997.

Interactions moves to _setup_interaction_information, which vanilla calls when the target changes and whenever is_synchronized_with_interactee reports the presentation stale. Because the preview also depends on how much room the player has left, PlayerWeapon raises a flag when local ammo changes and the update hook recomputes only then; on a quiet frame that costs one boolean test. The description is always rebuilt from the plain text vanilla wrote, so a refresh cannot compound the suffix. Havoc's ammo modifier now comes from game_mode:extension("havoc"):get_modifier_value(), cached for the mission, which also works on clients, unlike Managers.state.difficulty whose ammo modifier is only ever set on the server.

PlayerAbility drops its update hook for _set_progress plus _set_widget_state_colors. Both are needed: vanilla runs _set_progress before it refreshes self._on_cooldown and _set_widget_state_colors after, so the pair is correct on the frame an ability comes off cooldown where _set_progress alone would read a stale flag. Off cooldown the progress is constant and neither fires. TeamPlayerPanel drops its parallel cooldown tables and dt accumulation for the ability extension API, and the teammate exact ammo calculation, which duplicates vanilla's own weapon slot scan four panels deep, is throttled to about 10 Hz.

The dodge HUD deliberately does not cache from PlayerCharacterStateDodging or PlayerCharacterStateSliding as the issue suggested. Doing so leaves the display stale when a buff changes extra_consecutive_dodges mid-cooldown, which conflicts with keeping behaviour unchanged. The fields those transitions own are instead read every frame as a change detector, four cheap table reads, and the diminishing-return maths, colour writes and string.format are skipped when none of them moved. Extension and component handles are resolved once per player unit rather than once per frame, keyed on the live local player so a respawn picks up the new unit.

Four bugs surfaced while reworking these paths.
HudElementPlayerPanelBase.destroy indexed
self._widgets_by_name.ability_bar_widget, which does not exist, and threw whenever a panel was destroyed with the cooldown bar enabled. The weapon slots shared module-level previous-ammo and icon state and one ammo-gained widget pool, although there is one element per slot. The teammate cooldown bar guessed the full cooldown from the first remaining time it observed, so anyone joining mid-cooldown got a bar filling at the wrong rate; max_ability_cooldown is synced from the game object and gives the real value. The pickup preview wrote Havoc's reduced capacity permanently into the shared Pickups table, leaving it applied to every ammo pickup for the rest of the session; the modifier is now restored after asking for the amount.

Boss numbers cache on the widget's own content table, never on the widget group: vanilla's _draw_widgets iterates that group with pairs and hands every value to UIWidget.draw, so any extra field there is drawn as though it were a widget. Note that HudElementBossHealth, HudElementInteraction and the two elements this mod adds are not retained-mode, so dirtying their widgets does not gate the draw and the gain there is allocation churn rather than draw calls.

The library functions these files call are hoisted into module locals. Darktide calls jit.off() in boot_init, so the whole game runs on the LuaJIT interpreter with no trace compiler to hoist an invariant lookup out of a loop, and each math.floor costs a global table lookup plus a field lookup every time. Measured on the interpreter this is worth about 1.5 ns per avoided lookup, so roughly 0.3% of the dodge HUD's per-frame cost: worth having, not worth claiming. Deliberately excluded is ALIVE, which position_lookup_manager reassigns through rawset(_G, "ALIVE", ...), so a module-level upvalue would capture a stale table after a mission change; vanilla only ever caches it function-scoped. The same applies to anything hanging off Managers that is rebuilt per mission.

Measured across two missions, NumericUI's own HUD work fell from 39.4 to 14.2 microseconds per frame, a 64% reduction, with the local ammo readout down 92% per call and the ammo pickup preview down 89%.